### PR TITLE
Update optimade and docker CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,6 @@ jobs:
         pip install -U setuptools
         pip install -e .[dev]
 
-        # Until a newer version than 0.12.8 of `optimade` is released, we need to install from GitHub
-        pip install --force-reinstall git+https://github.com/Materials-Consortia/optimade-python-tools.git@master#egg=optimade
-
     - name: Test with pytest
       env:
         OPTIMADE_CI_FORCE_MONGO: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ WORKDIR /app
 COPY setup.py README.md requirements*.txt ./
 COPY optimade_gateway ./optimade_gateway
 COPY tests/static/test_gateways.json ./.ci/
-RUN apk add git \
-    && pip install git+https://github.com/Materials-Consortia/optimade-python-tools.git@master#egg=optimade \
-    && pip install -e .
+RUN pip install -e .
 
 EXPOSE 80
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 motor~=2.3
-optimade~=0.12.8
+optimade~=0.12.9
 uvicorn~=0.13.3


### PR DESCRIPTION
Fixes #13.
Fixes #8.

Use proper versions for the docker CI job and update `optimade` dependency.
Since the `optimade` package is updated, it can be installed from PyPI through and through.