### PR TITLE
Make tests more loose for model assertion

### DIFF
--- a/.ci/test_gateways.json
+++ b/.ci/test_gateways.json
@@ -9,7 +9,7 @@
         "attributes": {
           "name": "2D Structures",
           "description": "Two-dimensional (2D) materials from high-throughput computational exfoliation of experimentally known compounds.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/2dstructures/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/2dstructures/optimade",
           "homepage": "https://materialscloud.org/explore/2dstructures",
           "link_type": "child",
           "aggregate": "ok"
@@ -21,7 +21,7 @@
         "attributes": {
           "name": "OPTIMADE Sample Database",
           "description": "Database with example structures for OPTIMADE tests.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/optimade-sample/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/optimade-sample/optimade",
           "homepage": "https://materialscloud.org/explore/optimade-sample",
           "link_type": "child",
           "aggregate": "test"
@@ -33,7 +33,7 @@
         "attributes": {
           "name": "Automated high-throughput Wannierisation",
           "description": "Validation results of an automated protocol for generating maximally-localized Wannier functions in a high-throughput framework.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/autowannier/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/autowannier/optimade",
           "homepage": "https://materialscloud.org/explore/autowannier",
           "link_type": "child",
           "aggregate": "ok"
@@ -62,7 +62,7 @@
         "attributes": {
           "name": "2D Structures",
           "description": "Two-dimensional (2D) materials from high-throughput computational exfoliation of experimentally known compounds.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/2dstructures/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/2dstructures/optimade",
           "homepage": "https://materialscloud.org/explore/2dstructures",
           "link_type": "child",
           "aggregate": "ok"
@@ -74,7 +74,7 @@
         "attributes": {
           "name": "OPTIMADE Sample Database",
           "description": "Database with example structures for OPTIMADE tests.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/optimade-sample/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/optimade-sample/optimade",
           "homepage": "https://materialscloud.org/explore/optimade-sample",
           "link_type": "child",
           "aggregate": "test"
@@ -86,7 +86,7 @@
         "attributes": {
           "name": "Automated high-throughput Wannierisation",
           "description": "Validation results of an automated protocol for generating maximally-localized Wannier functions in a high-throughput framework.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/autowannier/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/autowannier/optimade",
           "homepage": "https://materialscloud.org/explore/autowannier",
           "link_type": "child",
           "aggregate": "ok"
@@ -104,7 +104,7 @@
         "attributes": {
           "name": "OPTIMADE Sample Database",
           "description": "Database with example structures for OPTIMADE tests.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/optimade-sample/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/optimade-sample/optimade",
           "homepage": "https://materialscloud.org/explore/optimade-sample",
           "link_type": "child",
           "aggregate": "test"
@@ -122,7 +122,7 @@
         "attributes": {
           "name": "2D Structures",
           "description": "Two-dimensional (2D) materials from high-throughput computational exfoliation of experimentally known compounds.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/2dstructures/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/2dstructures/optimade",
           "homepage": "https://materialscloud.org/explore/2dstructures",
           "link_type": "child",
           "aggregate": "ok"
@@ -134,7 +134,7 @@
         "attributes": {
           "name": "OPTIMADE Sample Database",
           "description": "Database with example structures for OPTIMADE tests.",
-          "base_url": "https://dev-aiida-dev.materialscloud.org/optimade-sample/optimade",
+          "base_url": "https://dev-aiida.materialscloud.org/optimade-sample/optimade",
           "homepage": "https://materialscloud.org/explore/optimade-sample",
           "link_type": "child",
           "aggregate": "test"

--- a/optimade_gateway/routers/structures.py
+++ b/optimade_gateway/routers/structures.py
@@ -138,12 +138,12 @@ async def get_structures(
 
     # Sort results over two steps, first by database id,
     # and then by (original) "id", since "id" MUST always be present.
-    if getattr(params, "response_fields", False):
-        results.sort(key=lambda data: data["id"])
-        results.sort(key=lambda data: "/".join(data["id"].split("/")[1:]))
-    else:
-        results.sort(key=lambda data: data.id)
-        results.sort(key=lambda data: "/".join(data.id.split("/")[1:]))
+    results.sort(key=lambda data: data["id"] if "id" in data else data.id)
+    results.sort(
+        key=lambda data: "/".join(data["id"].split("/")[1:])
+        if "id" in data
+        else "/".join(data.id.split("/")[1:])
+    )
 
     if more_data_available:
         # Deduce the `next` link from the current request

--- a/tests/routers/test_structures.py
+++ b/tests/routers/test_structures.py
@@ -54,11 +54,11 @@ async def test_get_structures(client, get_gateway):
 
     data.sort(key=lambda datum: datum["id"])
     data.sort(key=lambda datum: "/".join(datum["id"].split("/")[1:]))
-    assert [StructureResource(**_).dict() for _ in data] == [
-        _.dict() for _ in response.data
+    assert data == [
+        _.dict() if isinstance(_, StructureResource) else _ for _ in response.data
     ], (
-        f"IDs in test not in response: {set([_['id'] for _ in data]) - set([_.id for _ in response.data])}\n\n"
-        f"IDs in response not in test: {set([_.id for _ in response.data]) - set([_['id'] for _ in data])}\n\n"
+        f"IDs in test not in response: {set([_['id'] for _ in data]) - set([_.id if isinstance(_, StructureResource) else _['id'] for _ in response.data])}\n\n"
+        f"IDs in response not in test: {set([_.id if isinstance(_, StructureResource) else _['id'] for _ in response.data]) - set([_['id'] for _ in data])}\n\n"
     )
 
 
@@ -99,4 +99,8 @@ async def test_get_single_structure(client, get_gateway):
         db_response["meta"]["more_data_available"] == response.meta.more_data_available
     )
 
-    assert StructureResource(**db_response["data"]).dict() == response.data.dict()
+    assert (
+        db_response["data"] == response.data.dict()
+        if isinstance(response.data, StructureResource)
+        else response.data
+    )


### PR DESCRIPTION
Don't expect response resources to match the pydantic models for it,
e.g., StructureResource.

Sort agnostically from this model assumption as well.

Update test gateways to point to `dev-aiida` instead of `dev-aiida-dev`.