### PR TITLE
Use latest MongoDB v4 (v4.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
     services:
       mongo:
-        image: mongo:4.2
+        image: mongo:4
         ports:
         - 27017:27017
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   db:
-    image: mongo:4.2
+    image: mongo:4
     restart: on-failure
     networks:
       - gateway


### PR DESCRIPTION
Use Docker MongoDB image `4` (latest v4 version) instead of v4.2.