### PR TITLE
Use ref variable for actions/checkout

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,9 @@ on:
     types:
     - published
 
+env:
+  PUBLISH_UPDATE_BRANCH: main
+
 jobs:
 
   update-repo-and-release:
@@ -12,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'Materials-Consortia/optimade-gateway' && startsWith(github.ref, 'refs/tags/v')
     env:
-      PUBLISH_UPDATE_BRANCH: main
       GIT_USER_NAME: OPTIMADE Developers
       GIT_USER_EMAIL: "dev@optimade.org"
 
@@ -47,7 +49,6 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-        unprotect_reviews: false
         sleep: 15
         force: true
         tags: true
@@ -111,6 +112,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 2
+        ref: ${{ env.PUBLISH_UPDATE_BRANCH }}
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes #61 

This is needed for the build and deploy documentation job, since it
would otherwise use the workflow-specific SHA.