### PR TITLE
Update dependencies and GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-gateway'
-      uses: codecov/codecov-action@v1.5.2
+      uses: codecov/codecov-action@v2.0.1
       with:
         name: optimade-gateway
         files: ./coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     exclude: .*\.md$
 
 - repo: https://github.com/ambv/black
-  rev: 21.6b0
+  rev: 21.7b0
   hooks:
   - id: black
     name: Blacken

--- a/optimade_gateway/routers/databases.py
+++ b/optimade_gateway/routers/databases.py
@@ -120,7 +120,7 @@ async def get_database(
     result, _, fields = await DATABASES_COLLECTION.find(params=params)
 
     if fields and result is not None:
-        result = handle_response_fields(result, fields)[0]
+        result = handle_response_fields(result, fields, set())[0]
 
     return DatabasesResponseSingle(
         links=ToplevelLinks(next=None),

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -51,7 +51,7 @@ async def get_entries(
         links = ToplevelLinks(next=None)
 
     if fields:
-        results = handle_response_fields(results, fields)
+        results = handle_response_fields(results, fields, set())
 
     return response_cls(
         links=links,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 httpx~=0.18.2
 motor~=2.4
-optimade[server]~=0.16.0
+optimade[server]~=0.16.1


### PR DESCRIPTION
Update dependencies and GH Actions according to @dependabot.

Update pre-commit hook `black`.

Update usage of utility function `handle_response_fields()` from the `optimade` package.
As `included` fields is still not properly implemented, this should all be updated according to v0.16 of `optimade`.