### PR TITLE
Use `bandit`, `pylint`, `safety`, and `mypy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,32 @@ jobs:
     - name: Test with pre-commit
       run: SKIP=pylint pre-commit run --all-files --show-diff-on-failure
 
+  pylint-safety:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools
+        pip install -e .[dev]
+        pip install safety
+
+    - name: Run pylint
+      run: pylint --rcfile=pyproject.toml *.py optimade_gateway
+
+    - name: Run safety
+      run: pip freeze | safety check --stdin
+
   pytest:
     runs-on: ubuntu-latest
     # timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,14 @@ jobs:
         while IFS="" read -r line || [ -n "${line}" ]; do
             if [[ "${line}" =~ ^pre-commit.*$ ]]; then
                 pre_commit="${line}"
+            elif [[ "${line}" =~ ^pylint.*$ ]]; then
+                pylint="${line}"
+            elif [[ "${line}" =~ ^invoke.*$ ]]; then
+                invoke="${line}"
             fi
         done < requirements_dev.txt
 
-        pip install ${pre_commit}
+        pip install ${pre_commit} ${pylint} ${invoke}
 
     - name: Test with pre-commit
       run: SKIP=pylint pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         done < requirements_dev.txt
 
         pip install ${pre_commit}
+        pip install pylint
 
     - name: Test with pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools
-        pip install -e .[dev]
+        pip install -U -r requirements.txt -r requirements_dev.txt -r requirements_docs.txt
         pip install safety
 
     - name: Run pylint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,9 @@ jobs:
         done < requirements_dev.txt
 
         pip install ${pre_commit}
-        pip install pylint
 
     - name: Test with pre-commit
-      run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+      run: SKIP=pylint pre-commit run --all-files --show-diff-on-failure
 
   pytest:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
-logs/
+# Tools
 .coverage
 htmlcov/
+.mypy*
+.pytest*
+
+# Python
+*.egg*
+
+# Application
+logs/
+
+# Documentation
 site/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,4 @@ repos:
   rev: v0.910
   hooks:
   - id: mypy
+    exclude: ^tests/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,3 @@ repos:
   rev: v0.910
   hooks:
   - id: mypy
-    additional_dependencies: [types-PyYAML]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
     args: [-r]
     exclude: ^tests/.*$
 
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.910
+  hooks:
+  - id: mypy
+    exclude: ^tests/.*$
+
 - repo: local
   hooks:
   - id: pylint
@@ -28,9 +34,13 @@ repos:
     types: [python]
     require_serial: true
     exclude: ^tests/.*$
-
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
-  hooks:
-  - id: mypy
-    exclude: ^tests/.*$
+  - id: pytest-plugins
+    name: pytest required plugin versions
+    entry: invoke
+    args: [update-pytest-reqs]
+    language: python
+    always_run: true
+    types: [text]
+    pass_filenames: false
+    files: ^requirements_dev.txt$
+    description: Update the pytest plugins to be minimum the currently listed requirement versions.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,30 @@ repos:
     exclude: .*\.md$
 
 - repo: https://github.com/ambv/black
-  rev: 21.7b0
+  rev: 21.8b0
   hooks:
   - id: black
     name: Blacken
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: '3.9.2'
+- repo: https://github.com/PyCQA/bandit
+  rev: '1.7.0'
   hooks:
-  - id: flake8
-    args: [--count, --show-source, --statistics]
+  - id: bandit
+    args: [-r]
+    exclude: ^tests/.*$
+
+- repo: local
+  hooks:
+  - id: pylint
+    name: pylint
+    entry: pylint
+    language: python
+    types: [python]
+    require_serial: true
+    exclude: ^tests/.*$
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.910
+  hooks:
+  - id: mypy
+    additional_dependencies: [types-PyYAML]

--- a/docs/api_reference/queries/pagination.md
+++ b/docs/api_reference/queries/pagination.md
@@ -1,3 +1,0 @@
-# pagination
-
-::: optimade_gateway.queries.pagination

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,8 @@ plugins:
               - "!__json_encoder__$"
               - "!__all__$"
               - "!__config__$"
+              - "!__str__$"
+              - "!__repr__$"
               - "!ValidatorResults$"
             members: true
             inherited_members: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,9 @@ plugins:
             docstring_style: google
             docstring_options:
               replace_admonitions: true
+          setup_commands:
+            - import os
+            - os.environ["MKDOCS_BUILD"] = "1"
       watch:
         - optimade_gateway
   - awesome-pages

--- a/optimade_gateway/common/config.py
+++ b/optimade_gateway/common/config.py
@@ -38,10 +38,10 @@ class ServerConfig(OptimadeServerConfig):
     )
 
     @validator("mongo_uri")
-    def replace_with_env_vars(cls, v):
+    def replace_with_env_vars(cls, value: str) -> str:
         """Replace string variables with environment variables, if possible"""
-        res: str = v
-        for match in re.finditer(r"\{[^{}]+\}", v):
+        res = value
+        for match in re.finditer(r"\{[^{}]+\}", value):
             string_var = match.group()[1:-1]
             env_var = os.getenv(
                 string_var, os.getenv(string_var.upper(), os.getenv(string_var.lower()))
@@ -50,7 +50,7 @@ class ServerConfig(OptimadeServerConfig):
                 res = res.replace(match.group(), env_var)
             else:
                 warnings.warn(
-                    f"Could not find an environment variable for {match.group()!r} from mongo_uri: {v}",
+                    f"Could not find an environment variable for {match.group()!r} from mongo_uri: {value}",
                     OptimadeGatewayWarning,
                 )
         return res

--- a/optimade_gateway/common/config.py
+++ b/optimade_gateway/common/config.py
@@ -1,8 +1,8 @@
-"""Configuration of the FastAPI server"""
-# pylint: disable=no-self-argument
+"""Configuration of the FastAPI server."""
+# pylint: disable=no-self-use,no-self-argument
 import os
 import re
-import warnings
+from warnings import warn
 
 from optimade.server.config import ServerConfig as OptimadeServerConfig
 from pydantic import Field, validator
@@ -32,8 +32,8 @@ class ServerConfig(OptimadeServerConfig):
         True,
         description=(
             "Whether or not to load all valid OPTIMADE providers' databases from the "
-            "[Materials-Consortia list of OPTIMADE providers](https://providers.optimade.org) on "
-            "server startup."
+            "[Materials-Consortia list of OPTIMADE providers]"
+            "(https://providers.optimade.org) on server startup."
         ),
     )
 
@@ -49,9 +49,13 @@ class ServerConfig(OptimadeServerConfig):
             if env_var is not None:
                 res = res.replace(match.group(), env_var)
             else:
-                warnings.warn(
-                    f"Could not find an environment variable for {match.group()!r} from mongo_uri: {value}",
-                    OptimadeGatewayWarning,
+                warn(
+                    OptimadeGatewayWarning(
+                        detail=(
+                            "Could not find an environment variable for "
+                            f"{match.group()!r} from mongo_uri: {value}"
+                        )
+                    )
                 )
         return res
 

--- a/optimade_gateway/common/exceptions.py
+++ b/optimade_gateway/common/exceptions.py
@@ -1,3 +1,4 @@
+"""Specific OPTIMADE Gateway Python exceptions."""
 __all__ = ("OptimadeGatewayError",)
 
 

--- a/optimade_gateway/common/logger.py
+++ b/optimade_gateway/common/logger.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from uvicorn.logging import DefaultFormatter
 
-if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=ungrouped-imports
     import logging.handlers
 

--- a/optimade_gateway/common/logger.py
+++ b/optimade_gateway/common/logger.py
@@ -4,8 +4,12 @@ import logging
 import os
 from pathlib import Path
 import sys
+from typing import TYPE_CHECKING
 
 from uvicorn.logging import DefaultFormatter
+
+if TYPE_CHECKING:
+    import logging.handlers
 
 
 @contextmanager

--- a/optimade_gateway/common/logger.py
+++ b/optimade_gateway/common/logger.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING
 
 from uvicorn.logging import DefaultFormatter
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=ungrouped-imports
     import logging.handlers
 
 

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -1,16 +1,20 @@
 from enum import Enum
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
+if TYPE_CHECKING:
+    from typing import Any, Dict, Union
 
-async def clean_python_types(data: Any) -> Any:
+
+async def clean_python_types(data: "Any") -> "Any":
     """Turn any types into MongoDB-friendly Python types.
 
     Use `dict()` method for Pydantic models.
     Use `value` property for Enums.
     Turn tuples and sets into lists.
     """
+    res: "Any" = None
     if isinstance(data, (list, tuple, set)):
         res = []
         for datum in data:
@@ -33,11 +37,11 @@ async def clean_python_types(data: Any) -> Any:
 
 
 def get_resource_attribute(
-    resource: Union[BaseModel, Dict[str, Any], None],
+    resource: "Union[BaseModel, Dict[str, Any], None]",
     field: str,
-    default: Any = None,
+    default: "Any" = None,
     disambiguate: bool = True,
-) -> Any:
+) -> "Any":
     """Return a resource's field's value
 
     Get the field value no matter if the resource is a pydantic model or a Python dictionary.
@@ -68,7 +72,7 @@ def get_resource_attribute(
         _get_attr = getattr
     elif isinstance(resource, dict):
 
-        def _get_attr(mapping: dict, key: str, default: Any) -> Any:
+        def _get_attr(mapping: dict, key: str, default: "Any") -> "Any":  # type: ignore[misc]
             return mapping.get(key, default)
 
     elif resource is None:

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -1,7 +1,12 @@
+"""Common utility functions.
+
+These functions may be used in general throughout the OPTIMADE Gateway Python code.
+"""
+# pylint: disable=line-too-long
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel  # pylint: disable=no-name-in-module
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Union
@@ -61,8 +66,8 @@ def get_resource_attribute(
             `"attributes.base_url"`.
         default: The default value to return if `field` does not exist.
         disambiguate: Whether or not to "shortcut" a field value.
-            For example, for `attributes.base_url`, if `True`, this would return the string value
-            or the value of it's `"href"` key.
+            For example, for `attributes.base_url`, if `True`, this would return the
+            string value or the value of it's `"href"` key.
 
     Returns:
         The resource's field's value.
@@ -80,13 +85,13 @@ def get_resource_attribute(
         return default
     else:
         raise TypeError(
-            "resource must be either a pydantic model or a Python dictionary, it was of type "
-            f"{type(resource)!r}"
+            "resource must be either a pydantic model or a Python dictionary, it was of "
+            f"type {type(resource)!r}"
         )
 
     fields = field.split(".")
-    for field in fields[:-1]:
-        resource = _get_attr(resource, field, {})
+    for _ in fields[:-1]:
+        resource = _get_attr(resource, _, {})
     field = fields[-1]
     value = _get_attr(resource, field, default)
 

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -4,11 +4,13 @@ These functions may be used in general throughout the OPTIMADE Gateway Python co
 """
 # pylint: disable=line-too-long
 from enum import Enum
+from os import getenv
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import
     from typing import Any, Dict, Union
 
 

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import
     from typing import Any, Dict, Union
 

--- a/optimade_gateway/events.py
+++ b/optimade_gateway/events.py
@@ -1,7 +1,10 @@
-from typing import Callable, Tuple
+from typing import TYPE_CHECKING
 
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Coroutine, Sequence, Tuple, Union
 
 
 async def ci_dev_startup() -> None:
@@ -73,6 +76,9 @@ async def load_optimade_providers_databases() -> None:
             "Will not load databases from Materials-Consortia list of providers."
         )
         return
+
+    if TYPE_CHECKING:
+        providers: "Union[httpx.Response, LinksResponse]"
 
     async with httpx.AsyncClient() as client:
         providers = await client.get(
@@ -210,7 +216,7 @@ async def load_optimade_providers_databases() -> None:
             )
 
 
-EVENTS: Tuple[Tuple[str, Callable[[], None]]] = (
+EVENTS: "Sequence[Tuple[str, Callable[[], Coroutine[Any, Any, None]]]]" = (
     ("startup", ci_dev_startup),
     ("startup", load_optimade_providers_databases),
 )

--- a/optimade_gateway/events.py
+++ b/optimade_gateway/events.py
@@ -5,20 +5,20 @@ The specific events are listed in [`EVENTS`][optimade_gateway.events.EVENTS] alo
 their respected proper invocation time.
 """
 # pylint: disable=import-outside-toplevel
+import os
 from typing import TYPE_CHECKING
 
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import
     from typing import Any, Callable, Coroutine, Sequence, Tuple, Union
 
 
 async def ci_dev_startup() -> None:
     """Function to run at app startup - only relevant for CI or development to add test
     data."""
-    import os
-
     if bool(os.getenv("CI", "")):
         LOGGER.info(
             "CI detected - Will load test gateways (after dropping the collection)!"
@@ -86,7 +86,7 @@ async def load_optimade_providers_databases() -> None:  # pylint: disable=too-ma
         )
         return
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
         providers: "Union[httpx.Response, LinksResponse]"
 
     async with httpx.AsyncClient() as client:

--- a/optimade_gateway/events.py
+++ b/optimade_gateway/events.py
@@ -31,9 +31,18 @@ async def ci_dev_startup() -> None:
 
     await MONGO_DB[CONFIG.gateways_collection].drop()
 
-    assert await MONGO_DB[CONFIG.gateways_collection].count_documents({}) == 0
+    if await MONGO_DB[CONFIG.gateways_collection].count_documents({}) != 0:
+        raise RuntimeError(
+            f"Unexpectedly found documents in the {CONFIG.gateways_collection!r} Mongo"
+            " collection after dropping it ! Found number of documents: "
+            f"{await MONGO_DB[CONFIG.gateways_collection].count_documents({})}"
+        )
 
-    assert test_data.exists()
+    if not test_data.exists():
+        raise FileNotFoundError(
+            f"Could not find test data file with test gateways at {test_data} !"
+        )
+
     with open(test_data) as handle:
         data = json.load(handle)
     await MONGO_DB[CONFIG.gateways_collection].insert_many(data)

--- a/optimade_gateway/events.py
+++ b/optimade_gateway/events.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 
-if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import
     from typing import Any, Callable, Coroutine, Sequence, Tuple, Union
 
@@ -86,7 +86,7 @@ async def load_optimade_providers_databases() -> None:  # pylint: disable=too-ma
         )
         return
 
-    if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+    if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
         providers: "Union[httpx.Response, LinksResponse]"
 
     async with httpx.AsyncClient() as client:

--- a/optimade_gateway/exception_handlers.py
+++ b/optimade_gateway/exception_handlers.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from optimade.models import ErrorSource, OptimadeError
 from optimade.server.exception_handlers import general_exception
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import
     from fastapi import Request
     from fastapi.exceptions import RequestValidationError

--- a/optimade_gateway/exception_handlers.py
+++ b/optimade_gateway/exception_handlers.py
@@ -1,3 +1,9 @@
+"""ASGI app exception handlers.
+
+These are in addition to the exception handlers available in OPTIMADE Python tools.
+For more information see
+https://www.optimade.org/optimade-python-tools/api_reference/server/exception_handlers/.
+"""
 from typing import TYPE_CHECKING
 
 from optimade.models import ErrorSource, OptimadeError

--- a/optimade_gateway/exception_handlers.py
+++ b/optimade_gateway/exception_handlers.py
@@ -1,13 +1,17 @@
-from fastapi import Request
-from fastapi.exceptions import RequestValidationError
+from typing import TYPE_CHECKING
+
 from optimade.models import ErrorSource, OptimadeError
 from optimade.server.exception_handlers import general_exception
-from starlette.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from fastapi import Request
+    from fastapi.exceptions import RequestValidationError
+    from starlette.responses import JSONResponse
 
 
 async def request_validation_exception_handler(
-    request: Request, exc: RequestValidationError
-) -> JSONResponse:
+    request: "Request", exc: "RequestValidationError"
+) -> "JSONResponse":
     """Special handler if a `RequestValidationError` comes from wrong `POST` data"""
     status_code = 500
     if request.method in ("POST", "post"):

--- a/optimade_gateway/exception_handlers.py
+++ b/optimade_gateway/exception_handlers.py
@@ -4,12 +4,14 @@ These are in addition to the exception handlers available in OPTIMADE Python too
 For more information see
 https://www.optimade.org/optimade-python-tools/api_reference/server/exception_handlers/.
 """
+from os import getenv
 from typing import TYPE_CHECKING
 
 from optimade.models import ErrorSource, OptimadeError
 from optimade.server.exception_handlers import general_exception
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import
     from fastapi import Request
     from fastapi.exceptions import RequestValidationError
     from starlette.responses import JSONResponse

--- a/optimade_gateway/main.py
+++ b/optimade_gateway/main.py
@@ -59,7 +59,7 @@ APP.include_router(versions_router)
 # Add endpoints to / and /vMAJOR
 for prefix in list(BASE_URL_PREFIXES.values()) + [""]:
     for router in (databases, gateways, info, links, queries, search):
-        APP.include_router(router.ROUTER, prefix=prefix, include_in_schema=prefix == "")
+        APP.include_router(router.ROUTER, prefix=prefix, include_in_schema=prefix == "")  # type: ignore[attr-defined]
 
 for event, func in EVENTS:
     APP.add_event_handler(event, func)

--- a/optimade_gateway/main.py
+++ b/optimade_gateway/main.py
@@ -1,3 +1,4 @@
+"""The initialization of the ASGI FastAPI application."""
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import RedirectResponse
@@ -59,7 +60,11 @@ APP.include_router(versions_router)
 # Add endpoints to / and /vMAJOR
 for prefix in list(BASE_URL_PREFIXES.values()) + [""]:
     for router in (databases, gateways, info, links, queries, search):
-        APP.include_router(router.ROUTER, prefix=prefix, include_in_schema=prefix == "")  # type: ignore[attr-defined]
+        APP.include_router(
+            router.ROUTER,  # type: ignore[attr-defined]
+            prefix=prefix,
+            include_in_schema=prefix == "",
+        )
 
 for event, func in EVENTS:
     APP.add_event_handler(event, func)

--- a/optimade_gateway/mappers/__init__.py
+++ b/optimade_gateway/mappers/__init__.py
@@ -1,6 +1,6 @@
-from .databases import *  # noqa: F403
-from .gateways import *  # noqa: F403
-from .queries import *  # noqa: F403
+from .databases import DatabasesMapper
+from .gateways import GatewaysMapper
+from .queries import QueryMapper
 
 
-__all__ = databases.__all__ + gateways.__all__ + queries.__all__  # noqa: F405
+__all__ = ("DatabasesMapper", "GatewaysMapper", "QueryMapper")

--- a/optimade_gateway/mappers/__init__.py
+++ b/optimade_gateway/mappers/__init__.py
@@ -1,6 +1,11 @@
+"""OPTIMADE Gateway mappers for entry-endpoint resources.
+
+The design for these mappers is based on the mappers in OPTIMADE Python tools.
+"""
 from .databases import DatabasesMapper
 from .gateways import GatewaysMapper
+from .links import LinksMapper
 from .queries import QueryMapper
 
 
-__all__ = ("DatabasesMapper", "GatewaysMapper", "QueryMapper")
+__all__ = ("DatabasesMapper", "GatewaysMapper", "LinksMapper", "QueryMapper")

--- a/optimade_gateway/mappers/base.py
+++ b/optimade_gateway/mappers/base.py
@@ -1,9 +1,13 @@
-from typing import Iterable, List, Union
+from typing import TYPE_CHECKING
 
-from optimade.models import EntryResource
 from optimade.server.mappers.entries import (
     BaseResourceMapper as OptimadeBaseResourceMapper,
 )
+
+if TYPE_CHECKING:
+    from typing import Iterable, List, Union
+
+    from optimade.models import EntryResource
 
 
 class BaseResourceMapper(OptimadeBaseResourceMapper):
@@ -40,6 +44,6 @@ class BaseResourceMapper(OptimadeBaseResourceMapper):
 
     @classmethod
     async def deserialize(
-        cls, results: Union[dict, Iterable[dict]]
-    ) -> Union[List[EntryResource], EntryResource]:
+        cls, results: "Union[dict, Iterable[dict]]"
+    ) -> "Union[List[EntryResource], EntryResource]":
         return super(BaseResourceMapper, cls).deserialize(results)

--- a/optimade_gateway/mappers/base.py
+++ b/optimade_gateway/mappers/base.py
@@ -3,6 +3,7 @@
 
 Based on the [`BaseResourceMapper`](https://www.optimade.org/optimade-python-tools/api_reference/server/mappers/entries/#optimade.server.mappers.entries.BaseResourceMapper) in OPTIMADE Python tools.
 """
+from os import getenv
 from typing import TYPE_CHECKING
 
 from optimade.server.mappers.entries import (
@@ -12,7 +13,8 @@ from pydantic import AnyUrl
 
 from optimade_gateway.common.config import CONFIG
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import,ungrouped-imports
     from typing import Iterable, List, Union
 
     from optimade.models import EntryResource

--- a/optimade_gateway/mappers/base.py
+++ b/optimade_gateway/mappers/base.py
@@ -13,7 +13,7 @@ from pydantic import AnyUrl
 
 from optimade_gateway.common.config import CONFIG
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import,ungrouped-imports
     from typing import Iterable, List, Union
 

--- a/optimade_gateway/mappers/databases.py
+++ b/optimade_gateway/mappers/databases.py
@@ -1,4 +1,4 @@
-from pydantic import AnyUrl  # pylint: disable=no-name-in-module
+from pydantic import AnyUrl
 
 from optimade_gateway.common.config import CONFIG
 

--- a/optimade_gateway/mappers/databases.py
+++ b/optimade_gateway/mappers/databases.py
@@ -1,32 +1,12 @@
-from pydantic import AnyUrl
+# pylint: disable=line-too-long
+"""Resource mapper for resources under `/databases`.
 
-from optimade_gateway.common.config import CONFIG
-
+These resources are [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource)s.
+"""
 from optimade_gateway.mappers.links import LinksMapper
-
-__all__ = ("DatabasesMapper",)
 
 
 class DatabasesMapper(LinksMapper):
+    """`/databases`-endpoint resources mapper."""
 
     ENDPOINT = "databases"
-
-    @classmethod
-    def map_back(cls, doc: dict) -> dict:
-        from optimade.server.routers.utils import BASE_URL_PREFIXES
-
-        if "_id" in doc:
-            _id = str(doc.pop("_id"))
-            if "id" not in doc:
-                doc["id"] = _id
-
-        doc["links"] = {
-            "self": AnyUrl(
-                url=f"{CONFIG.base_url.strip('/')}{BASE_URL_PREFIXES['major']}/{cls.ENDPOINT}/{doc['id']}",
-                scheme=CONFIG.base_url.split("://")[0],
-                host=CONFIG.base_url.split("://")[1].split("/")[0],
-            )
-        }
-
-        # Ensure the type does not change to "databases"
-        return super().map_back(doc)

--- a/optimade_gateway/mappers/gateways.py
+++ b/optimade_gateway/mappers/gateways.py
@@ -1,4 +1,4 @@
-from pydantic import AnyUrl  # pylint: disable=no-name-in-module
+from pydantic import AnyUrl
 
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.models import GatewayResource

--- a/optimade_gateway/mappers/gateways.py
+++ b/optimade_gateway/mappers/gateways.py
@@ -1,32 +1,11 @@
-from pydantic import AnyUrl
-
-from optimade_gateway.common.config import CONFIG
+"""Resource mapper for
+[`GatewayResource`][optimade_gateway.models.gateways.GatewayResource]."""
 from optimade_gateway.models import GatewayResource
-
 from optimade_gateway.mappers.base import BaseResourceMapper
-
-__all__ = ("GatewaysMapper",)
 
 
 class GatewaysMapper(BaseResourceMapper):
+    """[`GatewayResource`][optimade_gateway.models.gateways.GatewayResource] mapper."""
 
     ENDPOINT = "gateways"
     ENTRY_RESOURCE_CLASS = GatewayResource
-
-    @classmethod
-    def map_back(cls, doc: dict) -> dict:
-        from optimade.server.routers.utils import BASE_URL_PREFIXES
-
-        if "_id" in doc:
-            _id = str(doc.pop("_id"))
-            if "id" not in doc:
-                doc["id"] = _id
-
-        doc["links"] = {
-            "self": AnyUrl(
-                url=f"{CONFIG.base_url.strip('/')}{BASE_URL_PREFIXES['major']}/{cls.ENDPOINT}/{doc['id']}",
-                scheme=CONFIG.base_url.split("://")[0],
-                host=CONFIG.base_url.split("://")[1].split("/")[0],
-            )
-        }
-        return super().map_back(doc)

--- a/optimade_gateway/mappers/links.py
+++ b/optimade_gateway/mappers/links.py
@@ -1,11 +1,20 @@
+# pylint: disable=line-too-long
+"""Replicate of
+[`LinksMapper`](https://www.optimade.org/optimade-python-tools/api_reference/server/mappers/links/#optimade.server.mappers.links.LinksMapper)
+in OPTIMADE Python tools."""
 from optimade.models.links import LinksResource
 
 from optimade_gateway.mappers.base import BaseResourceMapper
 
-__all__ = ("LinksMapper",)
-
 
 class LinksMapper(BaseResourceMapper):
+    """Replicate of
+    [`LinksMapper`](https://www.optimade.org/optimade-python-tools/api_reference/server/mappers/links/#optimade.server.mappers.links.LinksMapper)
+    in OPTIMADE Python tools.
+
+    This is based on the OPTIMADE Gateway
+    [`BaseResourceMapper`][optimade_gateway.mappers.base.BaseResourceMapper] however.
+    """
 
     ENDPOINT = "links"
     ENTRY_RESOURCE_CLASS = LinksResource

--- a/optimade_gateway/mappers/queries.py
+++ b/optimade_gateway/mappers/queries.py
@@ -1,4 +1,4 @@
-from pydantic import AnyUrl  # pylint: disable=no-name-in-module
+from pydantic import AnyUrl
 
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.models import QueryResource

--- a/optimade_gateway/mappers/queries.py
+++ b/optimade_gateway/mappers/queries.py
@@ -1,32 +1,11 @@
-from pydantic import AnyUrl
-
-from optimade_gateway.common.config import CONFIG
+"""Resource mapper for
+[`QueryResource`][optimade_gateway.models.queries.QueryResource]."""
 from optimade_gateway.models import QueryResource
-
 from optimade_gateway.mappers.base import BaseResourceMapper
-
-__all__ = ("QueryMapper",)
 
 
 class QueryMapper(BaseResourceMapper):
+    """[`QueryResource`][optimade_gateway.models.queries.QueryResource] mapper."""
 
     ENDPOINT = "queries"
     ENTRY_RESOURCE_CLASS = QueryResource
-
-    @classmethod
-    def map_back(cls, doc: dict) -> dict:
-        from optimade.server.routers.utils import BASE_URL_PREFIXES
-
-        if "_id" in doc:
-            _id = str(doc.pop("_id"))
-            if "id" not in doc:
-                doc["id"] = _id
-
-        doc["links"] = {
-            "self": AnyUrl(
-                url=f"{CONFIG.base_url.strip('/')}{BASE_URL_PREFIXES['major']}/{cls.ENDPOINT}/{doc['id']}",
-                scheme=CONFIG.base_url.split("://")[0],
-                host=CONFIG.base_url.split("://")[1].split("/")[0],
-            )
-        }
-        return super().map_back(doc)

--- a/optimade_gateway/middleware.py
+++ b/optimade_gateway/middleware.py
@@ -1,3 +1,9 @@
+"""ASGI app middleware.
+
+These are in addition to the middleware available in OPTIMADE Python tools.
+For more information see
+https://www.optimade.org/optimade-python-tools/api_reference/server/middleware/.
+"""
 import re
 from typing import TYPE_CHECKING
 
@@ -37,7 +43,8 @@ class CheckWronglyVersionedBaseUrlsGateways(BaseHTTPMiddleware):
                     detail=(
                         f"The parsed versioned base URL {match.group('version')!r} from "
                         f"{url} is not supported by this implementation. "
-                        f"Supported versioned base URLs are: {', '.join(BASE_URL_PREFIXES.values())}"
+                        "Supported versioned base URLs are: "
+                        f"{', '.join(BASE_URL_PREFIXES.values())}"
                     )
                 )
 

--- a/optimade_gateway/middleware.py
+++ b/optimade_gateway/middleware.py
@@ -4,6 +4,7 @@ These are in addition to the middleware available in OPTIMADE Python tools.
 For more information see
 https://www.optimade.org/optimade-python-tools/api_reference/server/middleware/.
 """
+from os import getenv
 import re
 from typing import TYPE_CHECKING
 
@@ -11,7 +12,8 @@ from optimade.server.exceptions import VersionNotSupported
 from optimade.server.routers.utils import BASE_URL_PREFIXES, get_base_url
 from starlette.middleware.base import BaseHTTPMiddleware
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import,ungrouped-imports
     from fastapi import Request
     from starlette.datastructures import URL
 

--- a/optimade_gateway/middleware.py
+++ b/optimade_gateway/middleware.py
@@ -1,10 +1,13 @@
 import re
+from typing import TYPE_CHECKING
 
-from fastapi import Request
 from optimade.server.exceptions import VersionNotSupported
 from optimade.server.routers.utils import BASE_URL_PREFIXES, get_base_url
-from starlette.datastructures import URL
 from starlette.middleware.base import BaseHTTPMiddleware
+
+if TYPE_CHECKING:
+    from fastapi import Request
+    from starlette.datastructures import URL
 
 
 class CheckWronglyVersionedBaseUrlsGateways(BaseHTTPMiddleware):
@@ -12,7 +15,7 @@ class CheckWronglyVersionedBaseUrlsGateways(BaseHTTPMiddleware):
     return `553 Version Not Supported`."""
 
     @staticmethod
-    async def check_url(url: URL):
+    async def check_url(url: "URL"):
         """Check URL path for versioned part.
 
         Parameters:
@@ -38,7 +41,7 @@ class CheckWronglyVersionedBaseUrlsGateways(BaseHTTPMiddleware):
                     )
                 )
 
-    async def dispatch(self, request: Request, call_next):
+    async def dispatch(self, request: "Request", call_next):
         if request.url.path:
             await self.check_url(request.url)
         response = await call_next(request)

--- a/optimade_gateway/middleware.py
+++ b/optimade_gateway/middleware.py
@@ -12,7 +12,7 @@ from optimade.server.exceptions import VersionNotSupported
 from optimade.server.routers.utils import BASE_URL_PREFIXES, get_base_url
 from starlette.middleware.base import BaseHTTPMiddleware
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import,ungrouped-imports
     from fastapi import Request
     from starlette.datastructures import URL

--- a/optimade_gateway/models/databases.py
+++ b/optimade_gateway/models/databases.py
@@ -1,4 +1,5 @@
 """Pydantic models/schemas for the LinksResource used in /databases"""
+# pylint: disable=no-self-argument,no-self-use,line-too-long
 from typing import Optional, Union
 
 from optimade.models import Link, LinksResourceAttributes
@@ -10,20 +11,21 @@ from optimade_gateway.models.resources import EntryResourceCreate
 
 
 class DatabaseCreate(EntryResourceCreate, LinksResourceAttributes):
-    """Model for creating new LinksResources representing /databases resources in the MongoDB
+    """Model for creating new LinksResources representing `/databases` resources in the
+    MongoDB.
 
     Required fields:
 
-    - name
-    - base_url
+    - `name`
+    - `base_url`
 
     Original required fields for a
     [`LinksResourceAttributes`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResourceAttributes)
     model:
 
-    - name
-    - description
-    - link_type
+    - `name`
+    - `description`
+    - `link_type`
 
     """
 
@@ -31,13 +33,17 @@ class DatabaseCreate(EntryResourceCreate, LinksResourceAttributes):
     base_url: Union[AnyUrl, Link]
     homepage: Optional[Union[AnyUrl, Link]] = StrictField(
         None,
-        description="JSON API links object, pointing to a homepage URL for this implementation",
+        description=(
+            "JSON API links object, pointing to a homepage URL for this implementation."
+        ),
     )
     link_type: Optional[LinkType] = StrictField(
         None,
         title="Link Type",
-        description="""The type of the linked relation.
-MUST be one of these values: 'child', 'root', 'external', 'providers'.""",
+        description=(
+            "The type of the linked relation.\nMUST be one of these values: 'child', "
+            "'root', 'external', 'providers'."
+        ),
     )
 
     @validator("link_type")
@@ -53,7 +59,7 @@ MUST be one of these values: 'child', 'root', 'external', 'providers'.""",
         """
         if value in (LinkType.ROOT, LinkType.PROVIDERS):
             raise ValueError(
-                "Databases with 'root' or 'providers' link_type is not allowed for gateway-usable "
-                f"database resources. Given link_type: {value}"
+                "Databases with 'root' or 'providers' link_type is not allowed for "
+                f"gateway-usable database resources. Given link_type: {value}"
             )
         return value

--- a/optimade_gateway/models/databases.py
+++ b/optimade_gateway/models/databases.py
@@ -41,7 +41,7 @@ MUST be one of these values: 'child', 'root', 'external', 'providers'.""",
     )
 
     @validator("link_type")
-    def ensure_database_link_type(cls, value) -> LinkType:
+    def ensure_database_link_type(cls, value: LinkType) -> LinkType:
         """Ensure databases are not index meta-database-only types
 
         I.e., ensure they're not of type `"root"` or `"providers"`.

--- a/optimade_gateway/models/gateways.py
+++ b/optimade_gateway/models/gateways.py
@@ -99,7 +99,7 @@ class GatewayResource(EntryResource):
     )
     type: str = Field(
         "gateways",
-        const="gateways",
+        const=True,
         description="The name of the type of an entry.",
         regex="^gateways$",
     )
@@ -136,7 +136,7 @@ class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
         None, description="A unique list of database IDs for registered databases."
     )
 
-    databases: Optional[List[LinksResource]]
+    databases: Optional[List[LinksResource]]  # type: ignore
 
     @root_validator
     def specify_databases(cls, values: dict) -> dict:

--- a/optimade_gateway/models/gateways.py
+++ b/optimade_gateway/models/gateways.py
@@ -1,5 +1,5 @@
-"""Pydantic models/schemas for the Gateways resource"""
-# pylint: disable=no-self-argument
+"""Pydantic models/schemas for the Gateways resource."""
+# pylint: disable=no-self-argument,no-self-use,too-few-public-methods
 from typing import List, Optional, Set
 import warnings
 
@@ -31,8 +31,8 @@ class GatewayResourceAttributes(EntryResourceAttributes):
         """
         if value.attributes.link_type in (LinkType.ROOT, LinkType.PROVIDERS):
             raise ValueError(
-                "Databases with 'root' or 'providers' link_type is not allowed for gateway "
-                f"resources. Given database: {value}"
+                "Databases with 'root' or 'providers' link_type is not allowed for "
+                f"gateway resources. Given database: {value}"
             )
         return value
 
@@ -53,10 +53,11 @@ class GatewayResourceAttributes(EntryResourceAttributes):
                 [_ for _ in value if _.attributes.base_url == base_url][0]
             )
         warnings.warn(
-            "Removed extra database entries for a gateway, because the base_url was repeated. The "
-            "first found database entry was kept, while the others were removed. Original number "
-            f"of databases: {len(value)}. New number of databases: {len(new_databases)} Repeated "
-            "base_urls (number of repeats): {}".format(
+            "Removed extra database entries for a gateway, because the base_url was "
+            "repeated. The first found database entry was kept, while the others were "
+            f"removed. Original number of databases: {len(value)}. New number of "
+            f"databases: {len(new_databases)} Repeated base_urls (number of repeats): "
+            "{}".format(
                 [
                     f"{base_url} ({db_base_urls.count(base_url)})"
                     for base_url in repeated_base_urls
@@ -71,8 +72,9 @@ class GatewayResource(EntryResource):
     """OPTIMADE gateway
 
     A resource representing a dynamic collection of OPTIMADE databases.
-    The gateway can be treated as any other OPTIMADE gateway, but the entries are an aggregate of
-    multiple databases. The `id` of each aggregated resource will reflect the originating database.
+    The gateway can be treated as any other OPTIMADE gateway, but the entries are an
+    aggregate of multiple databases. The `id` of each aggregated resource will reflect
+    the originating database.
     """
 
     id: str = OptimadeField(
@@ -83,7 +85,8 @@ class GatewayResource(EntryResource):
 
 - **Requirements/Conventions**:
     - **Support**: MUST be supported by all implementations, MUST NOT be `null`.
-    - **Query**: MUST be a queryable property with support for all mandatory filter features.
+    - **Query**: MUST be a queryable property with support for all mandatory filter
+      features.
     - **Response**: REQUIRED in the response.
     - **Gateway-specific**: MUST NOT contain a forward slash (`/`).
 
@@ -117,7 +120,8 @@ class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
 
 - **Requirements/Conventions**:
     - **Support**: MUST be supported by all implementations, MUST NOT be `null`.
-    - **Query**: MUST be a queryable property with support for all mandatory filter features.
+    - **Query**: MUST be a queryable property with support for all mandatory filter
+      features.
     - **Response**: REQUIRED in the response.
     - **Gateway-specific**: MUST NOT contain a forward slash (`/`).
 

--- a/optimade_gateway/models/queries.py
+++ b/optimade_gateway/models/queries.py
@@ -241,7 +241,7 @@ class QueryResource(EntryResource):
 
     type: str = Field(
         "queries",
-        const="queries",
+        const=True,
         description="The name of the type of an entry.",
         regex="^queries$",
     )
@@ -288,7 +288,7 @@ class QueryResource(EntryResource):
                 _entry["id"] = f"{database_provider_}/{entry_['id']}"
             else:
                 _entry = entry_.copy(deep=True)
-                _entry.id = f"{database_provider_}/{entry_.id}"
+                _entry.id = f"{database_provider_}/{entry_.id}"  # type: ignore[union-attr]
             return _entry
 
         if not self.attributes.response:
@@ -348,8 +348,8 @@ class QueryResource(EntryResource):
 class QueryCreate(EntryResourceCreate, QueryResourceAttributes):
     """Model for creating new Query resources in the MongoDB"""
 
-    state: Optional[QueryState]
-    endpoint: Optional[EndpointEntryType]
+    state: Optional[QueryState]  # type: ignore[assignment]
+    endpoint: Optional[EndpointEntryType]  # type: ignore[assignment]
 
     @validator("query_parameters")
     def sort_not_supported(

--- a/optimade_gateway/models/queries.py
+++ b/optimade_gateway/models/queries.py
@@ -1,4 +1,6 @@
-"""Pydantic models/schemas for the Queries resource"""
+"""Pydantic models/schemas for the Queries resource."""
+# pylint: disable=line-too-long,too-few-public-methods,no-self-argument,no-self-use
+from copy import deepcopy
 from datetime import timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
@@ -30,7 +32,8 @@ from optimade_gateway.warnings import SortNotSupported
 
 
 class EndpointEntryType(Enum):
-    """Entry endpoint resource types, mapping to their pydantic models from the `optimade` package."""
+    """Entry endpoint resource types, mapping to their pydantic models from the
+    `optimade` package."""
 
     REFERENCES = "references"
     STRUCTURES = "structures"
@@ -169,7 +172,10 @@ class GatewayQueryResponse(Response):
     )
     errors: Optional[List[OptimadeError]] = StrictField(
         [],
-        description="A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present.",
+        description=(
+            "A list of OPTIMADE-specific JSON API error objects, where the field detail "
+            "MUST be present."
+        ),
         uniqueItems=True,
     )
     included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(
@@ -205,7 +211,9 @@ class QueryResourceAttributes(EntryResourceAttributes):
     )
     query_parameters: OptimadeQueryParameters = Field(
         ...,
-        description="OPTIMADE query parameters for entry listing endpoints used for this query.",
+        description=(
+            "OPTIMADE query parameters for entry listing endpoints used for this query."
+        ),
         type="object",
     )
     state: QueryState = Field(
@@ -230,8 +238,8 @@ class QueryResourceAttributes(EntryResourceAttributes):
         """Temporarily only allow queries to "structures" endpoints."""
         if value != EndpointEntryType.STRUCTURES:
             raise NotImplementedError(
-                'OPTIMADE Gateway temporarily only supports queries to "structures" endpoints, '
-                'i.e.: endpoint="structures"'
+                'OPTIMADE Gateway temporarily only supports queries to "structures" '
+                'endpoints, i.e.: endpoint="structures"'
             )
         return value
 
@@ -255,8 +263,8 @@ class QueryResource(EntryResource):
     ) -> Union[EntryResponseMany, ErrorResponse]:
         """Return `attributes.response` as a valid OPTIMADE entry listing response.
 
-        Note, this method disregards the state of the query and will simply return the query results
-        as they currently are (if there are any at all).
+        Note, this method disregards the state of the query and will simply return the
+        query results as they currently are (if there are any at all).
 
         Parameters:
             url: Optionally, update the `meta.query.representation` value with this.
@@ -267,13 +275,15 @@ class QueryResource(EntryResource):
             or an error response, if errors were returned or occurred during the query.
 
         """
-        from copy import deepcopy
-        from optimade.server.routers.utils import meta_values
+        from optimade.server.routers.utils import (  # pylint: disable=import-outside-toplevel
+            meta_values,
+        )
 
         async def _update_id(
             entry_: Union[EntryResource, Dict[str, Any]], database_provider_: str
         ) -> Union[EntryResource, Dict[str, Any]]:
-            """Internal utility function to prepend the entries' `id` with `provider/database/`.
+            """Internal utility function to prepend the entries' `id` with
+            `provider/database/`.
 
             Parameters:
                 entry_: The entry as a model or a dictionary.
@@ -297,8 +307,8 @@ class QueryResource(EntryResource):
                 errors=[
                     {
                         "detail": (
-                            "Can not return as a valid OPTIMADE response as the query has not yet "
-                            "been initialized."
+                            "Can not return as a valid OPTIMADE response as the query has"
+                            " not yet been initialized."
                         ),
                         "id": "OPTIMADE_GATEWAY_QUERY_NOT_INITIALIZED",
                     }

--- a/optimade_gateway/models/resources.py
+++ b/optimade_gateway/models/resources.py
@@ -1,3 +1,9 @@
+"""Pydantic models/schemas for entry-endpoint resources.
+
+This module is mainly used for a special pydantic base model, which can be used as a
+mix-in class when creating entry-endpoint resources.
+"""
+# pylint: disable=too-few-public-methods
 from datetime import datetime
 from typing import Any, Optional
 
@@ -12,6 +18,8 @@ class EntryResourceCreate(EntryResourceAttributes):
     id: Optional[str]
 
     class Config:
+        """Silently discard extra initiation keys."""
+
         extra = "ignore"
 
     @classmethod

--- a/optimade_gateway/models/responses.py
+++ b/optimade_gateway/models/responses.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import List, Optional
 
 from optimade.models import EntryResponseMany, EntryResponseOne, LinksResource
 from pydantic import Field
@@ -15,7 +15,7 @@ class DatabasesResponse(EntryResponseMany):
     with the exception of the `data´ field's description.
     """
 
-    data: Union[List[LinksResource], List[Dict[str, Any]]] = Field(
+    data: List[LinksResource] = Field(
         ...,
         description="""List of unique OPTIMADE links resource objects.
 These links resource objects represents OPTIMADE databases that can be used for queries in gateways.""",
@@ -26,7 +26,7 @@ These links resource objects represents OPTIMADE databases that can be used for 
 class DatabasesResponseSingle(EntryResponseOne):
     """Successful response for `POST /databases` and `GET /databases/{database_id}`"""
 
-    data: Union[LinksResource, Dict[str, Any], None] = Field(
+    data: Optional[LinksResource] = Field(
         ...,
         description="""A unique OPTIMADE links resource object.
 The OPTIMADE links resource object has just been created or found according to the specific query parameter(s) or URL id.
@@ -37,7 +37,7 @@ It represents an OPTIMADE database that can be used for queries in gateways.""",
 class GatewaysResponse(EntryResponseMany):
     """Successful response for `GET /gateways`"""
 
-    data: Union[List[GatewayResource], List[Dict[str, Any]]] = Field(
+    data: List[GatewayResource] = Field(
         ...,
         description="""List of unique OPTIMADE gateway resource objects.""",
         uniqueItems=True,
@@ -47,7 +47,7 @@ class GatewaysResponse(EntryResponseMany):
 class GatewaysResponseSingle(EntryResponseOne):
     """Successful response for `POST /gateways` and `GET /gateways/{gateway_id}`"""
 
-    data: Union[GatewayResource, Dict[str, Any], None] = Field(
+    data: Optional[GatewayResource] = Field(
         ...,
         description="""A unique OPTIMADE gateway resource object.
 The OPTIMADE gateway resource object has just been created or found according to the specific query parameter(s) or URL id.""",
@@ -57,7 +57,7 @@ The OPTIMADE gateway resource object has just been created or found according to
 class QueriesResponse(EntryResponseMany):
     """Successful response for `GET /gateways/{gateway_ID}/queries`"""
 
-    data: Union[List[QueryResource], List[Dict[str, Any]]] = Field(
+    data: List[QueryResource] = Field(
         ...,
         description="List of unique OPTIMADE gateway query resource objects.",
         uniqueItems=True,
@@ -67,7 +67,7 @@ class QueriesResponse(EntryResponseMany):
 class QueriesResponseSingle(EntryResponseOne):
     """Successful response for `POST /gateways/{gateway_ID}/queries` and `GET /gateways/{gateway_ID}/queries/{query_id}`"""
 
-    data: Union[QueryResource, Dict[str, Any], None] = Field(
+    data: Optional[QueryResource] = Field(
         ...,
         description="""A unique OPTIMADE gateway query resource object.
 The OPTIMADE gateway query resource object has just been created or found according to the specific query parameter(s) or URL id.""",

--- a/optimade_gateway/models/responses.py
+++ b/optimade_gateway/models/responses.py
@@ -1,3 +1,5 @@
+"""Pydantic models/schemas for the API responses."""
+# pylint: disable=line-too-long,too-few-public-methods
 from typing import List, Optional
 
 from optimade.models import EntryResponseMany, EntryResponseOne, LinksResource
@@ -17,8 +19,11 @@ class DatabasesResponse(EntryResponseMany):
 
     data: List[LinksResource] = Field(
         ...,
-        description="""List of unique OPTIMADE links resource objects.
-These links resource objects represents OPTIMADE databases that can be used for queries in gateways.""",
+        description=(
+            "List of unique OPTIMADE links resource objects.\nThese links resource "
+            "objects represents OPTIMADE databases that can be used for queries in "
+            "gateways."
+        ),
         uniqueItems=True,
     )
 
@@ -28,9 +33,12 @@ class DatabasesResponseSingle(EntryResponseOne):
 
     data: Optional[LinksResource] = Field(
         ...,
-        description="""A unique OPTIMADE links resource object.
-The OPTIMADE links resource object has just been created or found according to the specific query parameter(s) or URL id.
-It represents an OPTIMADE database that can be used for queries in gateways.""",
+        description=(
+            "A unique OPTIMADE links resource object.\nThe OPTIMADE links resource object"
+            " has just been created or found according to the specific query parameter(s)"
+            " or URL id.\nIt represents an OPTIMADE database that can be used for queries"
+            " in gateways."
+        ),
     )
 
 
@@ -45,17 +53,20 @@ class GatewaysResponse(EntryResponseMany):
 
 
 class GatewaysResponseSingle(EntryResponseOne):
-    """Successful response for `POST /gateways` and `GET /gateways/{gateway_id}`"""
+    """Successful response for `POST /gateways` and `GET /gateways/{gateway_id}`."""
 
     data: Optional[GatewayResource] = Field(
         ...,
-        description="""A unique OPTIMADE gateway resource object.
-The OPTIMADE gateway resource object has just been created or found according to the specific query parameter(s) or URL id.""",
+        description=(
+            "A unique OPTIMADE gateway resource object.\nThe OPTIMADE gateway resource "
+            "object has just been created or found according to the specific query "
+            "parameter(s) or URL id."
+        ),
     )
 
 
 class QueriesResponse(EntryResponseMany):
-    """Successful response for `GET /gateways/{gateway_ID}/queries`"""
+    """Successful response for `GET /gateways/{gateway_ID}/queries`."""
 
     data: List[QueryResource] = Field(
         ...,
@@ -65,10 +76,14 @@ class QueriesResponse(EntryResponseMany):
 
 
 class QueriesResponseSingle(EntryResponseOne):
-    """Successful response for `POST /gateways/{gateway_ID}/queries` and `GET /gateways/{gateway_ID}/queries/{query_id}`"""
+    """Successful response for `POST /gateways/{gateway_ID}/queries`
+    and `GET /gateways/{gateway_ID}/queries/{query_id}`."""
 
     data: Optional[QueryResource] = Field(
         ...,
-        description="""A unique OPTIMADE gateway query resource object.
-The OPTIMADE gateway query resource object has just been created or found according to the specific query parameter(s) or URL id.""",
+        description=(
+            "A unique OPTIMADE gateway query resource object.\nThe OPTIMADE gateway query"
+            " resource object has just been created or found according to the specific "
+            "query parameter(s) or URL id."
+        ),
     )

--- a/optimade_gateway/models/search.py
+++ b/optimade_gateway/models/search.py
@@ -1,3 +1,5 @@
+"""Pydantic models/schemas for the Search resource."""
+# pylint: disable=no-self-argument,no-self-use
 from typing import Set
 import warnings
 
@@ -17,29 +19,33 @@ class Search(BaseModel):
 
     query_parameters: OptimadeQueryParameters = Field(
         {},
-        description="OPTIMADE query parameters for entry listing endpoints used for this query.",
+        description=(
+            "OPTIMADE query parameters for entry listing endpoints used for this query."
+        ),
     )
     database_ids: Set[str] = Field(
         set(),
         description=(
-            "A list of registered database IDs. Go to `/databases` to get all registered databases."
+            "A list of registered database IDs. Go to `/databases` to get all registered"
+            " databases."
         ),
     )
     optimade_urls: Set[AnyUrl] = Field(
         set(),
         description=(
-            "A list of OPTIMADE base URLs. If a versioned base URL is supplied it will be used as "
-            "is, as long as it represents a supported version. If an un-versioned base URL, "
-            "standard version negotiation will be conducted to get the versioned base URL, which "
-            "will be used as long as it represents a supported version. Note, a single URL can be "
-            "supplied as well, and it will automatically be wrapped in a list in the server logic."
+            "A list of OPTIMADE base URLs. If a versioned base URL is supplied it will be"
+            " used as is, as long as it represents a supported version. If an "
+            "un-versioned base URL, standard version negotiation will be conducted to get"
+            " the versioned base URL, which will be used as long as it represents a "
+            "supported version. Note, a single URL can be supplied as well, and it will "
+            "automatically be wrapped in a list in the server logic."
         ),
     )
     endpoint: str = Field(
         "structures",
         description=(
-            "The entry endpoint queried. According to the OPTIMADE specification, this is the same"
-            " as the resource's type."
+            "The entry endpoint queried. According to the OPTIMADE specification, this is"
+            " the same as the resource's type."
         ),
     )
 

--- a/optimade_gateway/mongo/__init__.py
+++ b/optimade_gateway/mongo/__init__.py
@@ -1,3 +1,4 @@
+"""Everything to do with the MongoDB backend."""
 from .collection import AsyncMongoCollection
 
 

--- a/optimade_gateway/mongo/__init__.py
+++ b/optimade_gateway/mongo/__init__.py
@@ -1,4 +1,4 @@
-from .collection import *  # noqa: F403
+from .collection import AsyncMongoCollection
 
 
-__all__ = collection.__all__  # noqa: F405
+__all__ = ("AsyncMongoCollection",)

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -4,21 +4,24 @@ import warnings
 
 from optimade.filterparser import LarkParser
 from optimade.filtertransformers.mongo import MongoTransformer
-from optimade.models import EntryResource
 from optimade.server.entry_collections.entry_collections import EntryCollection
 from optimade.server.exceptions import BadRequest, NotFound
-from optimade.server.mappers.entries import BaseResourceMapper
-from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
+from optimade.server.query_params import SingleEntryQueryParams
 from optimade.server.warnings import UnknownProviderProperty
 from pymongo.collection import Collection as MongoCollection
 
 from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import clean_python_types
-from optimade_gateway.models import EntryResourceCreate
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Set, Tuple, Union
+
+    from optimade.models import EntryResource
+    from optimade.server.mappers.entries import BaseResourceMapper
+    from optimade.server.query_params import EntryListingQueryParams
+
+    from optimade_gateway.models import EntryResourceCreate
 
 
 __all__ = ("AsyncMongoCollection",)
@@ -33,8 +36,8 @@ class AsyncMongoCollection(EntryCollection):
     def __init__(
         self,
         name: str,
-        resource_cls: EntryResource,
-        resource_mapper: BaseResourceMapper,
+        resource_cls: "EntryResource",
+        resource_mapper: "BaseResourceMapper",
     ):
         """Initialize the AsyncMongoCollection for the given parameters.
 
@@ -250,7 +253,7 @@ class AsyncMongoCollection(EntryCollection):
         ):
             raise RuntimeError(f"Cannot define an alias starting with a '$': {aliases}")
 
-    async def get_one(self, **criteria: "Dict[str, Any]") -> EntryResource:
+    async def get_one(self, **criteria: "Dict[str, Any]") -> "EntryResource":
         """Get one resource based on criteria
 
         Warning:
@@ -294,7 +297,7 @@ class AsyncMongoCollection(EntryCollection):
 
         return results
 
-    async def create_one(self, resource: EntryResourceCreate) -> EntryResource:
+    async def create_one(self, resource: "EntryResourceCreate") -> "EntryResource":
         """Create a new document in the MongoDB collection based on query parameters.
 
         Update the newly created document with an `"id"` field.

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -272,7 +272,7 @@ class AsyncMongoCollection(EntryCollection):
             )
 
         if results:
-            results = await self.resource_mapper.deserialize(results)
+            results = await self.resource_mapper.adeserialize(results)
 
         return (  # type: ignore[return-value]
             results,

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -1,6 +1,13 @@
+# pylint: disable=line-too-long,too-many-branches
+"""MongoDB collection for entry-endpoint resources.
+
+The [`AsyncMongoCollection`][optimade_gateway.mongo.collection.AsyncMongoCollection]
+represents an asynchronous version of the equivalent MongoDB collection in `optimade`:
+[`MongoCollection`](https://www.optimade.org/optimade-python-tools/api_reference/server/entry_collections/mongo/#optimade.server.entry_collections.mongo.MongoCollection).
+"""
 from datetime import datetime
 from typing import TYPE_CHECKING
-import warnings
+from warnings import warn
 
 from optimade.filterparser import LarkParser
 from optimade.filtertransformers.mongo import MongoTransformer
@@ -15,7 +22,7 @@ from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Set, Tuple, Union
+    from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
     from optimade.models import EntryResource
     from optimade.server.mappers.entries import BaseResourceMapper
@@ -30,7 +37,8 @@ __all__ = ("AsyncMongoCollection",)
 class AsyncMongoCollection(EntryCollection):
     """MongoDB Collection for use with `asyncio`
 
-    The asynchronicity is implemented using [`motor`](https://motor.readthedocs.io) and [`asyncio`](https://asyncio.readthedocs.io/).
+    The asynchronicity is implemented using [`motor`](https://motor.readthedocs.io) and
+    [`asyncio`](https://asyncio.readthedocs.io/).
     """
 
     def __init__(
@@ -44,10 +52,13 @@ class AsyncMongoCollection(EntryCollection):
         Parameters:
             name: The name of the collection.
             resource_cls: The `EntryResource` model that is stored by the collection.
-            resource_mapper: A resource mapper object that handles aliases and format changes between deserialization and response.
+            resource_mapper: A resource mapper object that handles aliases and format
+                changes between deserialization and response.
 
         """
-        from optimade_gateway.mongo.database import MONGO_DB
+        from optimade_gateway.mongo.database import (  # pylint: disable=import-outside-toplevel
+            MONGO_DB,
+        )
 
         super().__init__(
             resource_cls=resource_cls,
@@ -64,41 +75,77 @@ class AsyncMongoCollection(EntryCollection):
 
     def __str__(self) -> str:
         """Standard printing result for an instance."""
-        return f"<{self.__class__.__name__}: resource={self.resource_cls.__name__} endpoint(mapper)={self.resource_mapper.ENDPOINT} DB_collection={self.collection.name}>"
+        return (
+            f"<{self.__class__.__name__}: resource={self.resource_cls.__name__} "
+            f"endpoint(mapper)={self.resource_mapper.ENDPOINT} "
+            f"DB_collection={self.collection.name}>"
+        )
 
     def __repr__(self) -> str:
         """Representation of instance."""
-        return f"{self.__class__.__name__}(name={self.collection.name!r}, resource_cls={self.resource_cls!r}, resource_mapper={self.resource_mapper!r})"
+        return (
+            f"{self.__class__.__name__}(name={self.collection.name!r}, "
+            f"resource_cls={self.resource_cls!r}, "
+            f"resource_mapper={self.resource_mapper!r})"
+        )
 
     def __len__(self) -> int:
-        import warnings
-
-        warnings.warn(
+        warn(
             OptimadeGatewayWarning(
-                detail="Cannot calculate length of collection using `len()`. Use `count()` instead."
+                detail=(
+                    "Cannot calculate length of collection using `len()`. Use `count()` "
+                    "instead."
+                )
             )
         )
         return 0
 
-    async def insert(self, data: "List[EntryResource]") -> None:
+    def insert(self, data: "List[EntryResource]") -> None:
+        raise NotImplementedError(
+            "This method cannot be used with this class and is a remnant from the parent "
+            "class. Use instead the asynchronous method `ainsert(data: "
+            "List[EntryResource])`."
+        )
+
+    async def ainsert(self, data: "List[EntryResource]") -> None:
+        """Add the given entries to the underlying database.
+
+        This is the asynchronous version of the parent class method named `insert()`.
+
+        Arguments:
+            data: The entry resource objects to add to the database.
+
+        """
         await self.collection.insert_many(await clean_python_types(data))
 
-    async def count(
+    def count(self, **kwargs) -> int:
+        raise NotImplementedError(
+            "This method cannot be used with this class and is a remnant from the parent "
+            "class. Use instead the asynchronous method `acount(params: "
+            "Optional[Union[EntryListingQueryParams, SingleEntryQueryParams]], "
+            "**kwargs)`."
+        )
+
+    async def acount(
         self,
-        params: "Union[EntryListingQueryParams, SingleEntryQueryParams]" = None,
+        params: "Optional[Union[EntryListingQueryParams, SingleEntryQueryParams]]" = None,
         **kwargs,
     ) -> int:
-        """Count documents in Collection
+        """Count documents in Collection.
+
+        This is the asynchronous version of the parent class method named `count()`.
 
         Parameters:
-            params: URL query parameters, either from a general entry endpoint or a single-entry endpoint.
+            params: URL query parameters, either from a general entry endpoint or a
+                single-entry endpoint.
             kwargs (dict): Query parameters as keyword arguments. Valid keys will be passed
                 to the
                 [`AsyncIOMotorCollection.count_documents`](https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_collection.html#motor.motor_asyncio.AsyncIOMotorCollection.count_documents)
                 method.
 
         Returns:
-            int: The number of entries matching the query specified by the keyword arguments.
+            int: The number of entries matching the query specified by the keyword
+                arguments.
 
         """
         if params is not None and kwargs:
@@ -125,23 +172,37 @@ class AsyncMongoCollection(EntryCollection):
 
         return await self.collection.count_documents(**criteria)
 
-    async def find(
+    def find(
+        self, params: "Union[EntryListingQueryParams, SingleEntryQueryParams]"
+    ) -> "Tuple[Union[List[EntryResource], EntryResource, None], int, bool, Set[str], Set[str]]":
+        raise NotImplementedError(
+            "This method cannot be used with this class and is a remnant from the parent "
+            "class. Use instead the asynchronous method `afind(params: "
+            "Optional[Union[EntryListingQueryParams, SingleEntryQueryParams]], criteria: "
+            "Optional[Dict[str, Any]])`."
+        )
+
+    async def afind(
         self,
-        params: "Union[EntryListingQueryParams, SingleEntryQueryParams]" = None,
-        criteria: "Dict[str, Any]" = None,
+        params: "Optional[Union[EntryListingQueryParams, SingleEntryQueryParams]]" = None,
+        criteria: "Optional[Dict[str, Any]]" = None,
     ) -> "Tuple[Union[List[EntryResource], EntryResource, None], int, bool, Set[str], Set[str]]":
         """Perform the query on the underlying MongoDB Collection, handling projection
         and pagination of the output.
 
+        This is the asynchronous version of the parent class method named `count()`.
+
         Either provide `params` or `criteria`. Not both, but at least one.
 
         Parameters:
-            params: URL query parameters, either from a general entry endpoint or a single-entry endpoint.
+            params: URL query parameters, either from a general entry endpoint or a
+                single-entry endpoint.
             criteria: Already handled/parsed URL query parameters.
 
         Returns:
             A list of entry resource objects, how much data was returned for the query,
-            whether more data is available with pagination, and fields (excluded, included).
+            whether more data is available with pagination, and fields (excluded,
+            included).
 
         """
         if (params is None and criteria is None) or (
@@ -171,7 +232,9 @@ class AsyncMongoCollection(EntryCollection):
 
             if data_returned > 1:
                 raise NotFound(
-                    detail=f"Instead of a single entry, {data_returned} entries were found",
+                    detail=(
+                        f"Instead of a single entry, {data_returned} entries were found"
+                    ),
                 )
 
         include_fields = (
@@ -191,15 +254,21 @@ class AsyncMongoCollection(EntryCollection):
                     bad_optimade_fields.add(field)
 
         if bad_provider_fields:
-            warnings.warn(
+            warn(
                 UnknownProviderProperty(
-                    detail=f"Unrecognised field(s) for this provider requested in `response_fields`: {bad_provider_fields}."
+                    detail=(
+                        "Unrecognised field(s) for this provider requested in "
+                        f"`response_fields`: {bad_provider_fields}."
+                    )
                 )
             )
 
         if bad_optimade_fields:
             raise BadRequest(
-                detail=f"Unrecognised OPTIMADE field(s) in requested `response_fields`: {bad_optimade_fields}."
+                detail=(
+                    "Unrecognised OPTIMADE field(s) in requested `response_fields`: "
+                    f"{bad_optimade_fields}."
+                )
             )
 
         if results:
@@ -213,14 +282,68 @@ class AsyncMongoCollection(EntryCollection):
             include_fields,
         )
 
-    async def handle_query_params(
+    def handle_query_params(
         self, params: "Union[EntryListingQueryParams, SingleEntryQueryParams]"
     ) -> "Dict[str, Any]":
+        raise NotImplementedError(
+            "This method cannot be used with this class and is a remnant from the parent "
+            "class. Use instead the asynchronous method `ahandle_query_params(params: "
+            "Union[EntryListingQueryParams, SingleEntryQueryParams])`."
+        )
+
+    async def ahandle_query_params(
+        self, params: "Union[EntryListingQueryParams, SingleEntryQueryParams]"
+    ) -> "Dict[str, Any]":
+        """Parse and interpret the backend-agnostic query parameter models into a
+        dictionary that can be used by the specific backend.
+
+        This is the asynchronous version of the parent class method named
+        `handle_query_params()`.
+
+        Note:
+            Currently this method returns the pymongo interpretation of the parameters,
+            which will need modification for modified for other backends.
+
+        Parameters:
+            params: The initialized query parameter model from the server.
+
+        Raises:
+            Forbidden: If too large of a page limit is provided.
+            BadRequest: If an invalid request is made, e.g., with incorrect fields or
+                response format.
+
+        Returns:
+            A dictionary representation of the query parameters.
+
+        """
         return super().handle_query_params(params)
 
-    async def _run_db_query(
-        self, criteria: "Dict[str, Any]", single_entry: bool
+    def _run_db_query(
+        self, criteria: "Dict[str, Any]", single_entry: bool = False
     ) -> "Tuple[List[Dict[str, Any]], int, bool]":
+        raise NotImplementedError(
+            "This method cannot be used with this class and is a remnant from the parent "
+            "class. Use instead the asynchronous method `_arun_db_query(criteria: "
+            "Dict[str, Any], single_entry: bool)`."
+        )
+
+    async def _arun_db_query(
+        self, criteria: "Dict[str, Any]", single_entry: bool = False
+    ) -> "Tuple[List[Dict[str, Any]], int, bool]":
+        """Run the query on the backend and collect the results.
+
+        This is the asynchronous version of the parent class method named `count()`.
+
+        Arguments:
+            criteria: A dictionary representation of the query parameters.
+            single_entry: Whether or not the caller is expecting a single entry response.
+
+        Returns:
+            The list of entries from the database (without any re-mapping), the total
+            number of entries matching the query and a boolean for whether or not there
+            is more data available.
+
+        """
         results = []
         async for document in self.collection.find(**self._valid_find_keys(**criteria)):
             if criteria.get("projection", {}).get("_id"):
@@ -238,7 +361,8 @@ class AsyncMongoCollection(EntryCollection):
 
         return results, data_returned, more_data_available
 
-    def _check_aliases(self, aliases: "Tuple[Tuple[str, str]]") -> None:
+    @staticmethod
+    def _check_aliases(aliases: "Tuple[Tuple[str, str]]") -> None:
         """Check that aliases do not clash with mongo keywords.
 
         Parameters:

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -22,7 +22,7 @@ from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Dict, List, Optional, Set, Tuple, Union
 

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -154,7 +154,7 @@ class AsyncMongoCollection(EntryCollection):
             )
 
         if params is not None:
-            kwargs = await self.handle_query_params(params)
+            kwargs = await self.ahandle_query_params(params)
 
         valid_method_keys = (
             "filter",
@@ -216,13 +216,13 @@ class AsyncMongoCollection(EntryCollection):
         # this is an unknown factor - better to then get a list of results.
         single_entry = False
         if criteria is None:
-            criteria = await self.handle_query_params(params)
+            criteria = await self.ahandle_query_params(params)
         else:
             single_entry = isinstance(params, SingleEntryQueryParams)
 
         response_fields = criteria.pop("fields", self.all_fields)
 
-        results, data_returned, more_data_available = await self._run_db_query(
+        results, data_returned, more_data_available = await self._arun_db_query(
             criteria=criteria,
             single_entry=single_entry,
         )
@@ -356,7 +356,7 @@ class AsyncMongoCollection(EntryCollection):
         else:
             criteria_nolimit = criteria.copy()
             criteria_nolimit.pop("limit", None)
-            data_returned = await self.count(params=None, **criteria_nolimit)
+            data_returned = await self.acount(params=None, **criteria_nolimit)
             more_data_available = len(results) < data_returned
 
         return results, data_returned, more_data_available

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -177,6 +177,23 @@ class AsyncMongoCollection(EntryCollection):
     def find(
         self, params: "Union[EntryListingQueryParams, SingleEntryQueryParams]"
     ) -> "Tuple[Union[List[EntryResource], EntryResource, None], int, bool, Set[str], Set[str]]":
+        """
+        Fetches results and indicates if more data is available.
+
+        Also gives the total number of data available in the absence of `page_limit`.
+        See
+        [`EntryListingQueryParams`](https://www.optimade.org/optimade-python-tools/api_reference/server/query_params/#optimade.server.query_params.EntryListingQueryParams)
+        for more information.
+
+        Parameters:
+            params: Entry listing URL query params.
+
+        Returns:
+            A tuple of various relevant values:
+            (`results`, `data_returned`, `more_data_available`, `exclude_fields`,
+            `include_fields`).
+
+        """
         raise NotImplementedError(
             "This method cannot be used with this class and is a remnant from the parent "
             "class. Use instead the asynchronous method `afind(params: "
@@ -287,6 +304,25 @@ class AsyncMongoCollection(EntryCollection):
     def handle_query_params(
         self, params: "Union[EntryListingQueryParams, SingleEntryQueryParams]"
     ) -> "Dict[str, Any]":
+        """Parse and interpret the backend-agnostic query parameter models into a
+        dictionary that can be used by the specific backend.
+
+        Note:
+            Currently this method returns the pymongo interpretation of the parameters,
+            which will need modification for modified for other backends.
+
+        Parameters:
+            params: The initialized query parameter model from the server.
+
+        Raises:
+            Forbidden: If too large of a page limit is provided.
+            BadRequest: If an invalid request is made, e.g., with incorrect fields
+                or response format.
+
+        Returns:
+            A dictionary representation of the query parameters.
+
+        """
         raise NotImplementedError(
             "This method cannot be used with this class and is a remnant from the parent "
             "class. Use instead the asynchronous method `ahandle_query_params(params: "

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -6,6 +6,7 @@ represents an asynchronous version of the equivalent MongoDB collection in `opti
 [`MongoCollection`](https://www.optimade.org/optimade-python-tools/api_reference/server/entry_collections/mongo/#optimade.server.entry_collections.mongo.MongoCollection).
 """
 from datetime import datetime
+from os import getenv
 from typing import TYPE_CHECKING
 from warnings import warn
 
@@ -21,7 +22,8 @@ from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
     from optimade.models import EntryResource

--- a/optimade_gateway/mongo/database.py
+++ b/optimade_gateway/mongo/database.py
@@ -1,12 +1,16 @@
+from typing import TYPE_CHECKING
+
 from motor.motor_asyncio import AsyncIOMotorClient
-from pymongo.database import Database
-from pymongo.mongo_client import MongoClient
 
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 
+if TYPE_CHECKING:
+    from pymongo.database import Database
+    from pymongo.mongo_client import MongoClient
 
-MONGO_CLIENT: MongoClient = AsyncIOMotorClient(
+
+MONGO_CLIENT: "MongoClient" = AsyncIOMotorClient(
     CONFIG.mongo_uri,
     appname="optimade-gateway",
     readConcernLevel="majority",
@@ -15,7 +19,7 @@ MONGO_CLIENT: MongoClient = AsyncIOMotorClient(
 )
 """The MongoDB motor client."""
 
-MONGO_DB: Database = MONGO_CLIENT[CONFIG.mongo_database]
+MONGO_DB: "Database" = MONGO_CLIENT[CONFIG.mongo_database]
 """The MongoDB motor database.
 This is a representation of the database used for the gateway service."""
 

--- a/optimade_gateway/mongo/database.py
+++ b/optimade_gateway/mongo/database.py
@@ -1,4 +1,5 @@
 """Initialize the MongoDB database."""
+from os import getenv
 from typing import TYPE_CHECKING
 
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -6,7 +7,8 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import
     from pymongo.database import Database
     from pymongo.mongo_client import MongoClient
 

--- a/optimade_gateway/mongo/database.py
+++ b/optimade_gateway/mongo/database.py
@@ -7,7 +7,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import
     from pymongo.database import Database
     from pymongo.mongo_client import MongoClient

--- a/optimade_gateway/mongo/database.py
+++ b/optimade_gateway/mongo/database.py
@@ -1,3 +1,4 @@
+"""Initialize the MongoDB database."""
 from typing import TYPE_CHECKING
 
 from motor.motor_asyncio import AsyncIOMotorClient

--- a/optimade_gateway/queries/__init__.py
+++ b/optimade_gateway/queries/__init__.py
@@ -1,5 +1,0 @@
-from .params import SearchQueryParams
-from .perform import db_find, perform_query
-
-
-__all__ = ("db_find", "perform_query", "SearchQueryParams")

--- a/optimade_gateway/queries/params.py
+++ b/optimade_gateway/queries/params.py
@@ -1,3 +1,5 @@
+"""URL query parameters."""
+# pylint: disable=line-too-long,too-few-public-methods
 from typing import Set
 
 from fastapi import Query
@@ -9,34 +11,37 @@ class SearchQueryParams:
 
     This is an extension of the
     [`EntryListingQueryParams`](https://www.optimade.org/optimade-python-tools/api_reference/server/query_params/#optimade.server.query_params.EntryListingQueryParams)
-    class in `optimade´, which defines the standard entry listing endpoint query parameters.
+    class in `optimade´, which defines the standard entry listing endpoint query
+    parameters.
 
     The extra query parameters are as follows.
 
     Attributes:
-        database_ids (Set[str]): List of possible database IDs that are already known by the gateway.
-            To be known they need to be registered with the gateway (currently not possible).
+        database_ids (Set[str]): List of possible database IDs that are already known by
+            the gateway. To be known they need to be registered with the gateway
+            (currently not possible).
 
-        optimade_urls (Set[AnyUrl]): A list of OPTIMADE base URLs. If a versioned
-            base URL is supplied it will be used as is, as long as it represents a supported
-            version. If an un-versioned base URL, standard version negotiation will be conducted to
-            get the versioned base URL, which will be used as long as it represents a supported
-            version.
+        optimade_urls (Set[AnyUrl]): A list of OPTIMADE base URLs. If a versioned base
+            URL is supplied it will be used as is, as long as it represents a supported
+            version. If an un-versioned base URL, standard version negotiation will be
+            conducted to get the versioned base URL, which will be used as long as it
+            represents a supported version.
 
             **Example**: `http://example.org/optimade/v1/search?optimade_urls="https://example.org/optimade_db/v1","https://optimade.herokuapp.com"`
 
-        endpoint (str): The entry endpoint queried. According to the OPTIMADE specification, this
-            is the same as the resource's type.
+        endpoint (str): The entry endpoint queried. According to the OPTIMADE
+            specification, this is the same as the resource's type.
 
             **Example**: `structures`
 
-        timeout (int): Timeout time (in seconds) to wait for a query to finish before redirecting
-            (*after* starting the query). Note, if the query has not finished after the timeout
-            time, a redirection will still be performed, but to a zero-results page, which can be
-            refreshed to get the finished query (once it has finished).
+        timeout (int): Timeout time (in seconds) to wait for a query to finish before
+            redirecting (*after* starting the query). Note, if the query has not finished
+            after the timeout time, a redirection will still be performed, but to a
+            zero-results page, which can be refreshed to get the finished query (once it
+            has finished).
 
-        as_optimade (bool): Return the response as a standard OPTIMADE entry listing endpoint
-            response. Otherwise, the response will be based on the
+        as_optimade (bool): Return the response as a standard OPTIMADE entry listing
+            endpoint response. Otherwise, the response will be based on the
             [`QueriesResponseSingle`][optimade_gateway.models.responses.QueriesResponseSingle]
             model.
 
@@ -48,40 +53,43 @@ class SearchQueryParams:
         database_ids: Set[str] = Query(
             set(),
             description=(
-                "Unique list of possible database IDs that are already known by the gateway. To be"
-                " known they need to be registered with the gateway (currently not possible)."
+                "Unique list of possible database IDs that are already known by the "
+                "gateway. To be known they need to be registered with the gateway "
+                "(currently not possible)."
             ),
         ),
         optimade_urls: Set[AnyUrl] = Query(
             set(),
             description=(
-                "A unique list of OPTIMADE base URLs. If a versioned base URL is supplied it will "
-                "be used as is, as long as it represents a supported version. If an un-versioned "
-                "base URL, standard version negotiation will be conducted to get the versioned "
-                "base URL, which will be used as long as it represents a supported version."
+                "A unique list of OPTIMADE base URLs. If a versioned base URL is "
+                "supplied it will be used as is, as long as it represents a supported "
+                "version. If an un-versioned base URL, standard version negotiation will"
+                " be conducted to get the versioned base URL, which will be used as long"
+                " as it represents a supported version."
             ),
         ),
         endpoint: str = Query(
             "structures",
             description=(
-                "The entry endpoint queried. According to the OPTIMADE specification, this is the "
-                "same as the resource's type."
+                "The entry endpoint queried. According to the OPTIMADE specification, "
+                "this is the same as the resource's type."
             ),
         ),
         timeout: int = Query(
             15,
             description=(
-                "Timeout time (in seconds) to wait for a query to finish before redirecting "
-                "(*after* starting the query). Note, if the query has not finished after the "
-                "timeout time, a redirection will still be performed, but to a zero-results page, "
-                "which can be refreshed to get the finished query (once it has finished)."
+                "Timeout time (in seconds) to wait for a query to finish before "
+                "redirecting (*after* starting the query). Note, if the query has not "
+                "finished after the timeout time, a redirection will still be performed,"
+                " but to a zero-results page, which can be refreshed to get the finished"
+                " query (once it has finished)."
             ),
         ),
         as_optimade: bool = Query(
             False,
             description=(
-                "Return the response as a standard OPTIMADE entry listing endpoint response. "
-                "Otherwise, the response will be based on the "
+                "Return the response as a standard OPTIMADE entry listing endpoint "
+                "response. Otherwise, the response will be based on the "
                 "[`QueriesResponseSingle`][optimade_gateway.models.responses.QueriesResponseSingle]"
                 " model."
             ),

--- a/optimade_gateway/queries/perform.py
+++ b/optimade_gateway/queries/perform.py
@@ -1,5 +1,5 @@
 """Perform OPTIMADE queries"""
-# pylint: disable=import-outside-toplevel,cyclic-import
+# pylint: disable=import-outside-toplevel
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import functools
@@ -20,6 +20,7 @@ from optimade.server.routers.utils import BASE_URL_PREFIXES, meta_values
 # from optimade.server.routers.utils import get_base_url
 from pydantic import ValidationError
 
+from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import get_resource_attribute
 from optimade_gateway.models import (
@@ -30,6 +31,7 @@ from optimade_gateway.models import (
 from optimade_gateway.queries.prepare import get_query_params, prepare_query_filter
 from optimade_gateway.queries.process import process_db_response
 from optimade_gateway.queries.utils import update_query
+from optimade_gateway.routers.utils import collection_factory, get_valid_resource
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, Union
@@ -60,13 +62,11 @@ async def perform_query(
         [`GatewayQueryResponse`][optimade_gateway.models.queries.GatewayQueryResponse].
 
     """
-    from optimade_gateway.routers.gateways import GATEWAYS_COLLECTION
-    from optimade_gateway.routers.utils import get_valid_resource
-
     await update_query(query, "state", QueryState.STARTED)
 
     gateway: GatewayResource = await get_valid_resource(
-        GATEWAYS_COLLECTION, query.attributes.gateway_id
+        await collection_factory(CONFIG.gateways_collection),
+        query.attributes.gateway_id,
     )
 
     filter_queries = await prepare_query_filter(

--- a/optimade_gateway/queries/perform.py
+++ b/optimade_gateway/queries/perform.py
@@ -4,39 +4,46 @@ from concurrent.futures import ThreadPoolExecutor
 import functools
 import json
 import os
-from typing import Any, Dict, List, Tuple, Union
-import urllib.parse
+from typing import TYPE_CHECKING
 
+# import urllib.parse
+
+import httpx
 from optimade import __api_version__
 from optimade.models import (
     EntryResource,
-    EntryResponseMany,
-    EntryResponseOne,
     ErrorResponse,
-    LinksResource,
     ToplevelLinks,
 )
-from optimade.server.routers.utils import BASE_URL_PREFIXES, get_base_url, meta_values
+from optimade.server.routers.utils import BASE_URL_PREFIXES, meta_values
+
+# from optimade.server.routers.utils import get_base_url
 from pydantic import ValidationError
-from starlette.datastructures import URL
 
 from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import get_resource_attribute
 from optimade_gateway.models import (
     GatewayQueryResponse,
     GatewayResource,
-    QueryResource,
     QueryState,
 )
 from optimade_gateway.queries.prepare import get_query_params, prepare_query_filter
 from optimade_gateway.queries.process import process_db_response
 from optimade_gateway.queries.utils import update_query
 
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Tuple, Union
+
+    from optimade.models import EntryResponseMany, EntryResponseOne, LinksResource
+    from starlette.datastructures import URL
+
+    from optimade_gateway.models import QueryResource
+
 
 async def perform_query(
-    url: URL,
-    query: QueryResource,
-) -> Union[EntryResponseMany, ErrorResponse, GatewayQueryResponse]:
+    url: "URL",
+    query: "QueryResource",
+) -> "Union[EntryResponseMany, ErrorResponse, GatewayQueryResponse]":
     """Perform OPTIMADE query with gateway.
 
     Parameters:
@@ -76,12 +83,15 @@ async def perform_query(
                 more_data_available=False,
             ),
         ),
+        operator=None,
         **{"$set": {"state": QueryState.IN_PROGRESS}},
     )
 
     loop = asyncio.get_running_loop()
     with ThreadPoolExecutor(
-        max_workers=min(32, os.cpu_count() + 4, len(gateway.attributes.databases))
+        max_workers=min(
+            32, (os.cpu_count() or 0) + 4, len(gateway.attributes.databases)
+        )
     ) as executor:
         # Run OPTIMADE DB queries in a thread pool, i.e., not using the main OS thread, where the
         # asyncio event loop is running.
@@ -108,42 +118,45 @@ async def perform_query(
         for query_task in query_tasks:
             (db_response, db_id) = await query_task
 
-            results = await process_db_response(
+            await process_db_response(
                 response=db_response,
                 database_id=db_id,
                 query=query,
                 gateway=gateway,
             )
 
-    if get_resource_attribute(
-        query,
-        "attributes.response.meta.more_data_available",
-        False,
-        disambiguate=False,  # Extremely minor speed-up
-    ):
-        # Deduce the `next` link from the current request
-        query_string = urllib.parse.parse_qs(url.query)
-        query_string["page_offset"] = int(
-            query_string.get("page_offset", [0])[0]
-        ) + len(results[: query.attributes.query_parameters.page_limit])
-        urlencoded = urllib.parse.urlencode(query_string, doseq=True)
-        base_url = get_base_url(url)
+            # Pagination
+            #
+            # if isinstance(results, list) and get_resource_attribute(
+            #     query,
+            #     "attributes.response.meta.more_data_available",
+            #     False,
+            #     disambiguate=False,  # Extremely minor speed-up
+            # ):
+            #     # Deduce the `next` link from the current request
+            #     query_string = urllib.parse.parse_qs(url.query)
+            #     query_string["page_offset"] = [
+            #         int(query_string.get("page_offset", [0])[0])  # type: ignore[list-item]
+            #         + len(results[: query.attributes.query_parameters.page_limit])
+            #     ]
+            #     urlencoded = urllib.parse.urlencode(query_string, doseq=True)
+            #     base_url = get_base_url(url)
 
-        links = ToplevelLinks(next=f"{base_url}{url.path}?{urlencoded}")
+            #     links = ToplevelLinks(next=f"{base_url}{url.path}?{urlencoded}")
 
-        await update_query(query, "response.links", links)
+            #     await update_query(query, "response.links", links)
 
     await update_query(query, "state", QueryState.FINISHED)
     return query.attributes.response
 
 
 def db_find(
-    database: Union[LinksResource, Dict[str, Any]],
+    database: "Union[LinksResource, Dict[str, Any]]",
     endpoint: str,
-    response_model: Union[EntryResponseMany, EntryResponseOne],
+    response_model: "Union[EntryResponseMany, EntryResponseOne]",
     query_params: str = "",
     raw_url: str = None,
-) -> Tuple[Union[ErrorResponse, EntryResponseMany, EntryResponseOne], str]:
+) -> "Tuple[Union[ErrorResponse, EntryResponseMany, EntryResponseOne], str]":
     """Imitate `Collection.find()` for any given database for entry-resource endpoints
 
     Parameters:
@@ -160,7 +173,8 @@ def db_find(
         Response as an `optimade` pydantic model and the `database`'s ID.
 
     """
-    import httpx
+    if TYPE_CHECKING:
+        response: "Union[httpx.Response, Dict[str, Any], EntryResponseMany, EntryResponseOne, ErrorResponse]"
 
     if raw_url:
         url = raw_url
@@ -169,7 +183,7 @@ def db_find(
             f"{str(get_resource_attribute(database, 'attributes.base_url')).strip('/')}"
             f"{BASE_URL_PREFIXES['major']}/{endpoint.strip('/')}?{query_params}"
         )
-    response: httpx.Response = httpx.get(url, timeout=60)
+    response = httpx.get(url, timeout=60)
 
     try:
         response = response.json()
@@ -254,14 +268,12 @@ def db_find(
 
 
 async def db_get_all_resources(
-    database: Union[LinksResource, Dict[str, Any]],
+    database: "Union[LinksResource, Dict[str, Any]]",
     endpoint: str,
-    response_model: EntryResponseMany,
+    response_model: "EntryResponseMany",
     query_params: str = "",
     raw_url: str = None,
-) -> Tuple[
-    List[Union[EntryResource, Dict[str, Any]]], Union[LinksResource, Dict[str, Any]]
-]:
+) -> "Tuple[List[Union[EntryResource, Dict[str, Any]]], Union[LinksResource, Dict[str, Any]]]":
     """Recursively retrieve all resources from an entry-listing endpoint
 
     This function keeps pulling the `links.next` link if `meta.more_data_available` is `True` to

--- a/optimade_gateway/queries/perform.py
+++ b/optimade_gateway/queries/perform.py
@@ -33,7 +33,8 @@ from optimade_gateway.queries.process import process_db_response
 from optimade_gateway.queries.utils import update_query
 from optimade_gateway.routers.utils import collection_factory, get_valid_resource
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Dict, List, Tuple, Union
 
     from optimade.models import (
@@ -178,7 +179,7 @@ def db_find(
         Response as an `optimade` pydantic model and the `database`'s ID.
 
     """
-    if TYPE_CHECKING:
+    if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
         response: "Union[httpx.Response, Dict[str, Any], EntryResponseMany, EntryResponseOne, ErrorResponse]"  # pylint: disable=line-too-long
 
     if raw_url:

--- a/optimade_gateway/queries/perform.py
+++ b/optimade_gateway/queries/perform.py
@@ -1,4 +1,5 @@
 """Perform OPTIMADE queries"""
+# pylint: disable=import-outside-toplevel,cyclic-import
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import functools
@@ -11,7 +12,6 @@ from typing import TYPE_CHECKING
 import httpx
 from optimade import __api_version__
 from optimade.models import (
-    EntryResource,
     ErrorResponse,
     ToplevelLinks,
 )
@@ -34,7 +34,12 @@ from optimade_gateway.queries.utils import update_query
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, Union
 
-    from optimade.models import EntryResponseMany, EntryResponseOne, LinksResource
+    from optimade.models import (
+        EntryResource,
+        EntryResponseMany,
+        EntryResponseOne,
+        LinksResource,
+    )
     from starlette.datastructures import URL
 
     from optimade_gateway.models import QueryResource
@@ -93,8 +98,8 @@ async def perform_query(
             32, (os.cpu_count() or 0) + 4, len(gateway.attributes.databases)
         )
     ) as executor:
-        # Run OPTIMADE DB queries in a thread pool, i.e., not using the main OS thread, where the
-        # asyncio event loop is running.
+        # Run OPTIMADE DB queries in a thread pool, i.e., not using the main OS thread,
+        # where the asyncio event loop is running.
         query_tasks = []
         for database in gateway.attributes.databases:
             query_params = await get_query_params(
@@ -125,26 +130,26 @@ async def perform_query(
                 gateway=gateway,
             )
 
-            # Pagination
-            #
-            # if isinstance(results, list) and get_resource_attribute(
-            #     query,
-            #     "attributes.response.meta.more_data_available",
-            #     False,
-            #     disambiguate=False,  # Extremely minor speed-up
-            # ):
-            #     # Deduce the `next` link from the current request
-            #     query_string = urllib.parse.parse_qs(url.query)
-            #     query_string["page_offset"] = [
-            #         int(query_string.get("page_offset", [0])[0])  # type: ignore[list-item]
-            #         + len(results[: query.attributes.query_parameters.page_limit])
-            #     ]
-            #     urlencoded = urllib.parse.urlencode(query_string, doseq=True)
-            #     base_url = get_base_url(url)
+    # Pagination
+    #
+    # if isinstance(results, list) and get_resource_attribute(
+    #     query,
+    #     "attributes.response.meta.more_data_available",
+    #     False,
+    #     disambiguate=False,  # Extremely minor speed-up
+    # ):
+    #     # Deduce the `next` link from the current request
+    #     query_string = urllib.parse.parse_qs(url.query)
+    #     query_string["page_offset"] = [
+    #         int(query_string.get("page_offset", [0])[0])  # type: ignore[list-item]
+    #         + len(results[: query.attributes.query_parameters.page_limit])
+    #     ]
+    #     urlencoded = urllib.parse.urlencode(query_string, doseq=True)
+    #     base_url = get_base_url(url)
 
-            #     links = ToplevelLinks(next=f"{base_url}{url.path}?{urlencoded}")
+    #     links = ToplevelLinks(next=f"{base_url}{url.path}?{urlencoded}")
 
-            #     await update_query(query, "response.links", links)
+    #     await update_query(query, "response.links", links)
 
     await update_query(query, "state", QueryState.FINISHED)
     return query.attributes.response
@@ -160,8 +165,8 @@ def db_find(
     """Imitate `Collection.find()` for any given database for entry-resource endpoints
 
     Parameters:
-        database: The OPTIMADE implementation to be queried. It **must** have a valid base URL and
-            id.
+        database: The OPTIMADE implementation to be queried.
+            It **must** have a valid base URL and id.
         endpoint: The entry-listing endpoint, e.g., `"structures"`.
         response_model: The expected OPTIMADE pydantic response model, e.g.,
             `optimade.models.StructureResponseMany`.
@@ -174,7 +179,7 @@ def db_find(
 
     """
     if TYPE_CHECKING:
-        response: "Union[httpx.Response, Dict[str, Any], EntryResponseMany, EntryResponseOne, ErrorResponse]"
+        response: "Union[httpx.Response, Dict[str, Any], EntryResponseMany, EntryResponseOne, ErrorResponse]"  # pylint: disable=line-too-long
 
     if raw_url:
         url = raw_url
@@ -273,19 +278,19 @@ async def db_get_all_resources(
     response_model: "EntryResponseMany",
     query_params: str = "",
     raw_url: str = None,
-) -> "Tuple[List[Union[EntryResource, Dict[str, Any]]], Union[LinksResource, Dict[str, Any]]]":
+) -> "Tuple[List[Union[EntryResource, Dict[str, Any]]], Union[LinksResource, Dict[str, Any]]]":  # pylint: disable=line-too-long
     """Recursively retrieve all resources from an entry-listing endpoint
 
-    This function keeps pulling the `links.next` link if `meta.more_data_available` is `True` to
-    ultimately retrieve *all* entries for `endpoint`.
+    This function keeps pulling the `links.next` link if `meta.more_data_available` is
+    `True` to ultimately retrieve *all* entries for `endpoint`.
 
     !!! warning
-        This function can be dangerous if an endpoint with hundreds or thousands of entries is
-        requested.
+        This function can be dangerous if an endpoint with hundreds or thousands of
+        entries is requested.
 
     Parameters:
-        database: The OPTIMADE implementation to be queried. It **must** have a valid base URL and
-            id.
+        database: The OPTIMADE implementation to be queried.
+            It **must** have a valid base URL and id.
         endpoint: The entry-listing endpoint, e.g., `"structures"`.
         response_model: The expected OPTIMADE pydantic response model, e.g.,
             `optimade.models.StructureResponseMany`.
@@ -322,9 +327,9 @@ async def db_get_all_resources(
         next_page = get_resource_attribute(response, "links.next")
         if next_page is None:
             LOGGER.error(
-                "Could not find a 'next' link for an OPTIMADE query request to %r (id=%r). Cannot "
-                "get all resources from /%s, even though this was asked and `more_data_available` "
-                "is `True` in the response.",
+                "Could not find a 'next' link for an OPTIMADE query request to %r "
+                "(id=%r). Cannot get all resources from /%s, even though this was asked "
+                "and `more_data_available` is `True` in the response.",
                 get_resource_attribute(database, "attributes.name", "N/A"),
                 get_resource_attribute(database, "id"),
                 endpoint,

--- a/optimade_gateway/queries/perform.py
+++ b/optimade_gateway/queries/perform.py
@@ -33,7 +33,7 @@ from optimade_gateway.queries.process import process_db_response
 from optimade_gateway.queries.utils import update_query
 from optimade_gateway.routers.utils import collection_factory, get_valid_resource
 
-if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Dict, List, Tuple, Union
 
@@ -179,7 +179,7 @@ def db_find(
         Response as an `optimade` pydantic model and the `database`'s ID.
 
     """
-    if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+    if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
         response: "Union[httpx.Response, Dict[str, Any], EntryResponseMany, EntryResponseOne, ErrorResponse]"  # pylint: disable=line-too-long
 
     if raw_url:

--- a/optimade_gateway/queries/prepare.py
+++ b/optimade_gateway/queries/prepare.py
@@ -1,4 +1,5 @@
 """Prepare OPTIMADE queries."""
+from os import getenv
 import re
 from typing import TYPE_CHECKING
 import urllib.parse
@@ -6,7 +7,8 @@ from warnings import warn
 
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import,ungrouped-imports
     from typing import List, Mapping, Union
 
     from optimade_gateway.models.queries import OptimadeQueryParameters

--- a/optimade_gateway/queries/prepare.py
+++ b/optimade_gateway/queries/prepare.py
@@ -1,14 +1,17 @@
 import re
-from typing import Dict, List, Union
+from typing import TYPE_CHECKING
 import urllib.parse
 
 from optimade_gateway.models.queries import OptimadeQueryParameters
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
+if TYPE_CHECKING:
+    from typing import Dict, List, Mapping, Union
+
 
 async def prepare_query_filter(
-    database_ids: List[str], filter_query: Union[str, None]
-) -> Dict[str, Union[str, None]]:
+    database_ids: "List[str]", filter_query: "Union[str, None]"
+) -> "Mapping[str, Union[str, None]]":
     """Update the query parameter `filter` value to be database-specific
 
     This is needed due to the served change of `id` values.
@@ -24,10 +27,13 @@ async def prepare_query_filter(
         A mapping for database IDs to database-specific `filter` query parameter values.
 
     """
-    updated_filter = {}.fromkeys(database_ids, filter_query)
+    updated_filter: "Dict[str, Union[str, None]]" = {}.fromkeys(
+        database_ids, filter_query
+    )
 
     if not filter_query:
         return updated_filter
+    updated_filter: "Dict[str, str]"
 
     for id_match in re.finditer(
         r'"(?P<id_value_l>[^\s]*)"[\s]*(<|>|<=|>=|=|!=|CONTAINS|STARTS WITH|ENDS WITH|STARTS|ENDS)'
@@ -59,13 +65,13 @@ async def prepare_query_filter(
                     ),
                 )
             )
-    return updated_filter
+    return updated_filter  # type: ignore[return-value]
 
 
 async def get_query_params(
     query_parameters: OptimadeQueryParameters,
     database_id: str,
-    filter_mapping: Dict[str, Union[str, None]],
+    filter_mapping: "Mapping[str, Union[str, None]]",
 ) -> str:
     """Construct the parsed URL query parameters"""
     query_params = {

--- a/optimade_gateway/queries/prepare.py
+++ b/optimade_gateway/queries/prepare.py
@@ -7,7 +7,7 @@ from warnings import warn
 
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import,ungrouped-imports
     from typing import List, Mapping, Union
 

--- a/optimade_gateway/queries/prepare.py
+++ b/optimade_gateway/queries/prepare.py
@@ -2,11 +2,12 @@ import re
 from typing import TYPE_CHECKING
 import urllib.parse
 
-from optimade_gateway.models.queries import OptimadeQueryParameters
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Mapping, Union
+    from typing import List, Mapping, Union
+
+    from optimade_gateway.models.queries import OptimadeQueryParameters
 
 
 async def prepare_query_filter(
@@ -27,13 +28,10 @@ async def prepare_query_filter(
         A mapping for database IDs to database-specific `filter` query parameter values.
 
     """
-    updated_filter: "Dict[str, Union[str, None]]" = {}.fromkeys(
-        database_ids, filter_query
-    )
+    updated_filter = {}.fromkeys(database_ids, filter_query)
 
     if not filter_query:
         return updated_filter
-    updated_filter: "Dict[str, str]"
 
     for id_match in re.finditer(
         r'"(?P<id_value_l>[^\s]*)"[\s]*(<|>|<=|>=|=|!=|CONTAINS|STARTS WITH|ENDS WITH|STARTS|ENDS)'
@@ -45,7 +43,7 @@ async def prepare_query_filter(
         for database_id in database_ids:
             if matched_id.startswith(f"{database_id}/"):
                 # Database found
-                updated_filter[database_id] = updated_filter[database_id].replace(
+                updated_filter[database_id] = updated_filter[database_id].replace(  # type: ignore[union-attr]
                     f"{database_id}/", "", 1
                 )
                 break
@@ -69,7 +67,7 @@ async def prepare_query_filter(
 
 
 async def get_query_params(
-    query_parameters: OptimadeQueryParameters,
+    query_parameters: "OptimadeQueryParameters",
     database_id: str,
     filter_mapping: "Mapping[str, Union[str, None]]",
 ) -> str:

--- a/optimade_gateway/queries/process.py
+++ b/optimade_gateway/queries/process.py
@@ -122,6 +122,7 @@ async def process_db_response(
         query,
         f"response.data.{database_id}",
         results,
+        operator=None,
         **extra_updates,
     )
 

--- a/optimade_gateway/queries/process.py
+++ b/optimade_gateway/queries/process.py
@@ -1,29 +1,28 @@
 """Process performed OPTIMADE queries"""
-from typing import Any, Dict, List, Union
+from typing import TYPE_CHECKING
 
-from optimade.models import (
-    EntryResource,
-    EntryResponseMany,
-    EntryResponseOne,
-    ErrorResponse,
-    Meta,
-)
+from optimade.models import ErrorResponse, Meta
 
 from optimade_gateway.common.config import CONFIG
+from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import get_resource_attribute
-from optimade_gateway.models import GatewayResource, QueryResource
 from optimade_gateway.queries.utils import update_query
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Union
+
+    from optimade.models import EntryResource, EntryResponseMany, EntryResponseOne
+
+    from optimade_gateway.models import GatewayResource, QueryResource
+
 
 async def process_db_response(
-    response: Union[ErrorResponse, EntryResponseMany, EntryResponseOne],
+    response: "Union[ErrorResponse, EntryResponseMany, EntryResponseOne]",
     database_id: str,
-    query: QueryResource,
-    gateway: GatewayResource,
-) -> Union[
-    List[EntryResource], List[Dict[str, Any]], EntryResource, Dict[str, Any], None
-]:
+    query: "QueryResource",
+    gateway: "GatewayResource",
+) -> "Union[List[EntryResource], List[Dict[str, Any]], EntryResource, Dict[str, Any], None]":
     """Process an OPTIMADE database response.
 
     The passed `query` will be updated with the top-level `meta` information: `data_available`,
@@ -46,9 +45,7 @@ async def process_db_response(
     results = []
     errors = []
 
-    from optimade_gateway.common.logger import LOGGER
-
-    LOGGER.debug("database_id: %s", database_id)
+    LOGGER.debug("Starting to process database_id: %s", database_id)
 
     if isinstance(response, ErrorResponse):
         for error in response.errors:

--- a/optimade_gateway/queries/process.py
+++ b/optimade_gateway/queries/process.py
@@ -11,7 +11,7 @@ from optimade_gateway.common.utils import get_resource_attribute
 from optimade_gateway.queries.utils import update_query
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Dict, List, Union
 

--- a/optimade_gateway/queries/process.py
+++ b/optimade_gateway/queries/process.py
@@ -1,4 +1,5 @@
 """Process performed OPTIMADE queries."""
+from os import getenv
 from typing import TYPE_CHECKING
 from warnings import warn
 
@@ -10,7 +11,8 @@ from optimade_gateway.common.utils import get_resource_attribute
 from optimade_gateway.queries.utils import update_query
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Dict, List, Union
 
     from optimade.models import EntryResource, EntryResponseMany, EntryResponseOne

--- a/optimade_gateway/queries/utils.py
+++ b/optimade_gateway/queries/utils.py
@@ -3,8 +3,10 @@
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import clean_python_types
+from optimade_gateway.routers.utils import collection_factory
 
 if TYPE_CHECKING:
     from typing import Any, Optional
@@ -44,8 +46,6 @@ async def update_query(  # pylint: disable=too-many-branches
         mongo_kwargs (dict): Further MongoDB update filters.
 
     """
-    from optimade_gateway.routers.queries import QUERIES_COLLECTION
-
     operator = operator or "$set"
 
     if operator and not operator.startswith("$"):
@@ -67,7 +67,8 @@ async def update_query(  # pylint: disable=too-many-branches
             update_kwargs.update({operator: {field: value}})
 
     # MongoDB
-    result: "UpdateResult" = await QUERIES_COLLECTION.collection.update_one(
+    collection = await collection_factory(CONFIG.queries_collection)
+    result: "UpdateResult" = await collection.collection.update_one(
         filter={"id": {"$eq": query.id}},
         update=await clean_python_types(update_kwargs),
     )

--- a/optimade_gateway/queries/utils.py
+++ b/optimade_gateway/queries/utils.py
@@ -9,7 +9,7 @@ from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.routers.utils import collection_factory
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Optional
 

--- a/optimade_gateway/queries/utils.py
+++ b/optimade_gateway/queries/utils.py
@@ -1,16 +1,19 @@
+from datetime import datetime
 from typing import TYPE_CHECKING
 
-from pymongo.results import UpdateResult
-
 from optimade_gateway.common.logger import LOGGER
-from optimade_gateway.models import QueryResource
+from optimade_gateway.common.utils import clean_python_types
 
 if TYPE_CHECKING:
     from typing import Any, Optional
 
+    from pymongo.results import UpdateResult
+
+    from optimade_gateway.models import QueryResource
+
 
 async def update_query(
-    query: QueryResource,
+    query: "QueryResource",
     field: str,
     value: "Any",
     operator: "Optional[str]" = None,
@@ -39,9 +42,6 @@ async def update_query(
         mongo_kwargs (dict): Further MongoDB update filters.
 
     """
-    from datetime import datetime
-
-    from optimade_gateway.common.utils import clean_python_types
     from optimade_gateway.routers.queries import QUERIES_COLLECTION
 
     operator = operator or "$set"
@@ -65,7 +65,7 @@ async def update_query(
             update_kwargs.update({operator: {field: value}})
 
     # MongoDB
-    result: UpdateResult = await QUERIES_COLLECTION.collection.update_one(
+    result: "UpdateResult" = await QUERIES_COLLECTION.collection.update_one(
         filter={"id": {"$eq": query.id}},
         update=await clean_python_types(update_kwargs),
     )

--- a/optimade_gateway/queries/utils.py
+++ b/optimade_gateway/queries/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for the `queries` module."""
 # pylint: disable=import-outside-toplevel
 from datetime import datetime
+from os import getenv
 from typing import TYPE_CHECKING
 
 from optimade_gateway.common.config import CONFIG
@@ -8,7 +9,8 @@ from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.routers.utils import collection_factory
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Optional
 
     from pymongo.results import UpdateResult

--- a/optimade_gateway/queries/utils.py
+++ b/optimade_gateway/queries/utils.py
@@ -1,13 +1,20 @@
-from typing import Any
+from typing import TYPE_CHECKING
 
 from pymongo.results import UpdateResult
 
 from optimade_gateway.common.logger import LOGGER
 from optimade_gateway.models import QueryResource
 
+if TYPE_CHECKING:
+    from typing import Any, Optional
+
 
 async def update_query(
-    query: QueryResource, field: str, value: Any, operator: str = None, **mongo_kwargs
+    query: QueryResource,
+    field: str,
+    value: "Any",
+    operator: "Optional[str]" = None,
+    **mongo_kwargs,
 ) -> None:
     """Update a query's `field` attribute with `value`.
 

--- a/optimade_gateway/queries/utils.py
+++ b/optimade_gateway/queries/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions for the `queries` module."""
+# pylint: disable=import-outside-toplevel
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
     from optimade_gateway.models import QueryResource
 
 
-async def update_query(
+async def update_query(  # pylint: disable=too-many-branches
     query: "QueryResource",
     field: str,
     value: "Any",
@@ -21,12 +23,12 @@ async def update_query(
 ) -> None:
     """Update a query's `field` attribute with `value`.
 
-    If `field` is a dot-separated value, then only the last field part may be a non-pre-existing
-    field. Otherwise a `KeyError` or `AttributeError` will be raised.
+    If `field` is a dot-separated value, then only the last field part may be a
+    non-pre-existing field. Otherwise a `KeyError` or `AttributeError` will be raised.
 
     !!! note
-        This can *only* update a field for a query's `attributes`, i.e., this function cannot
-        update `id`, `type` or any other top-level resource field.
+        This can *only* update a field for a query's `attributes`, i.e., this function
+        cannot update `id`, `type` or any other top-level resource field.
 
     !!! important
         `mongo_kwargs` will not be considered for updating the pydantic model instance.
@@ -71,7 +73,10 @@ async def update_query(
     )
     if result.matched_count != 1:
         LOGGER.error(
-            "matched_count should have been exactly 1, it was: %s. Returned update_one result: %s",
+            (
+                "matched_count should have been exactly 1, it was: %s. "
+                "Returned update_one result: %s"
+            ),
             result.matched_count,
             result.raw_result,
         )

--- a/optimade_gateway/routers/databases.py
+++ b/optimade_gateway/routers/databases.py
@@ -91,7 +91,7 @@ async def post_databases(
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await DATABASES_COLLECTION.count(),
+            data_available=await DATABASES_COLLECTION.acount(),
             more_data_available=False,
             **{f"_{CONFIG.provider.prefix}_created": created},
         ),
@@ -125,7 +125,7 @@ async def get_database(
         more_data_available,
         fields,
         include_fields,
-    ) = await DATABASES_COLLECTION.find(params=params)
+    ) = await DATABASES_COLLECTION.afind(params=params)
 
     if fields or include_fields and result is not None:
         result = handle_response_fields(result, fields, include_fields)
@@ -138,7 +138,7 @@ async def get_database(
         meta=meta_values(
             url=request.url,
             data_returned=data_returned,
-            data_available=await DATABASES_COLLECTION.count(),
+            data_available=await DATABASES_COLLECTION.acount(),
             more_data_available=more_data_available,
         ),
     )

--- a/optimade_gateway/routers/databases.py
+++ b/optimade_gateway/routers/databases.py
@@ -11,29 +11,27 @@ Database resources represent the available databases that may be used for the ga
 One can register a new database (by using `POST /databases`) or look through the available
 databases (by using `GET /databases`) using standard OPTIMADE filtering.
 """
+# pylint: disable=line-too-long,import-outside-toplevel
 from fastapi import APIRouter, Depends, Request
-from optimade.models import LinksResource, ToplevelLinks
+from optimade.models import ToplevelLinks
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 from optimade.server.routers.utils import handle_response_fields, meta_values
 from optimade.server.schemas import ERROR_RESPONSES
 
 from optimade_gateway.common.config import CONFIG
-from optimade_gateway.mappers import DatabasesMapper
 from optimade_gateway.models import (
     DatabaseCreate,
     DatabasesResponse,
     DatabasesResponseSingle,
 )
-from optimade_gateway.mongo.collection import AsyncMongoCollection
+from optimade_gateway.routers.utils import (
+    collection_factory,
+    get_entries,
+    resource_factory,
+)
 
 
 ROUTER = APIRouter(redirect_slashes=True)
-
-DATABASES_COLLECTION = AsyncMongoCollection(
-    name=CONFIG.databases_collection,
-    resource_cls=LinksResource,
-    resource_mapper=DatabasesMapper,
-)
 
 
 @ROUTER.get(
@@ -53,10 +51,8 @@ async def get_databases(
 
     Return overview of all (active) databases.
     """
-    from optimade_gateway.routers.utils import get_entries
-
     return await get_entries(
-        collection=DATABASES_COLLECTION,
+        collection=await collection_factory(CONFIG.databases_collection),
         response_cls=DatabasesResponse,
         request=request,
         params=params,
@@ -81,9 +77,8 @@ async def post_databases(
     [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource),
     representing a database resource object, according to `database`.
     """
-    from optimade_gateway.routers.utils import resource_factory
-
     result, created = await resource_factory(database)
+    collection = await collection_factory(CONFIG.databases_collection)
 
     return DatabasesResponseSingle(
         links=ToplevelLinks(next=None),
@@ -91,7 +86,7 @@ async def post_databases(
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await DATABASES_COLLECTION.acount(),
+            data_available=await collection.acount(),
             more_data_available=False,
             **{f"_{CONFIG.provider.prefix}_created": created},
         ),
@@ -118,6 +113,8 @@ async def get_database(
     [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource)
     representing the database resource object with `id={database ID}`.
     """
+    collection = await collection_factory(CONFIG.databases_collection)
+
     params.filter = f'id="{database_id}"'
     (
         result,
@@ -125,7 +122,7 @@ async def get_database(
         more_data_available,
         fields,
         include_fields,
-    ) = await DATABASES_COLLECTION.afind(params=params)
+    ) = await collection.afind(params=params)
 
     if fields or include_fields and result is not None:
         result = handle_response_fields(result, fields, include_fields)
@@ -138,7 +135,7 @@ async def get_database(
         meta=meta_values(
             url=request.url,
             data_returned=data_returned,
-            data_available=await DATABASES_COLLECTION.acount(),
+            data_available=await collection.acount(),
             more_data_available=more_data_available,
         ),
     )

--- a/optimade_gateway/routers/databases.py
+++ b/optimade_gateway/routers/databases.py
@@ -130,7 +130,7 @@ async def get_database(
     if fields or include_fields and result is not None:
         result = handle_response_fields(result, fields, include_fields)
 
-    result = result[0] if data_returned else None
+    result = result[0] if isinstance(result, list) and data_returned else None
 
     return DatabasesResponseSingle(
         links=ToplevelLinks(next=None),

--- a/optimade_gateway/routers/gateways.py
+++ b/optimade_gateway/routers/gateways.py
@@ -6,29 +6,29 @@ This file describes the router for:
 
 where, `id` may be left out.
 """
+# pylint: disable=import-outside-toplevel
 from fastapi import APIRouter, Depends, Request
 from optimade.models import ToplevelLinks
 from optimade.server.query_params import EntryListingQueryParams
+from optimade.server.routers.utils import meta_values
 from optimade.server.schemas import ERROR_RESPONSES
 
 from optimade_gateway.common.config import CONFIG
-from optimade_gateway.mappers import GatewaysMapper
+from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.models import (
     GatewayCreate,
-    GatewayResource,
     GatewaysResponse,
     GatewaysResponseSingle,
 )
-from optimade_gateway.mongo.collection import AsyncMongoCollection
+from optimade_gateway.routers.utils import (
+    collection_factory,
+    get_entries,
+    get_valid_resource,
+    resource_factory,
+)
 
 
 ROUTER = APIRouter(redirect_slashes=True)
-
-GATEWAYS_COLLECTION = AsyncMongoCollection(
-    name=CONFIG.gateways_collection,
-    resource_cls=GatewayResource,
-    resource_mapper=GatewaysMapper,
-)
 
 
 @ROUTER.get(
@@ -48,10 +48,8 @@ async def get_gateways(
 
     Return overview of all (active) gateways.
     """
-    from optimade_gateway.routers.utils import get_entries
-
     return await get_entries(
-        collection=GATEWAYS_COLLECTION,
+        collection=await collection_factory(CONFIG.gateways_collection),
         response_cls=GatewaysResponse,
         request=request,
         params=params,
@@ -74,14 +72,10 @@ async def post_gateways(
 
     Create or return existing gateway according to `gateway`.
     """
-    from optimade.server.routers.utils import meta_values
-    from optimade_gateway.common.utils import clean_python_types
-    from optimade_gateway.routers.utils import resource_factory
-
     if gateway.database_ids:
-        from optimade_gateway.routers.databases import DATABASES_COLLECTION
+        databases_collection = await collection_factory(CONFIG.databases_collection)
 
-        databases = await DATABASES_COLLECTION.get_multiple(
+        databases = await databases_collection.get_multiple(
             filter={"id": {"$in": await clean_python_types(gateway.database_ids)}}
         )
 
@@ -94,6 +88,7 @@ async def post_gateways(
         )
 
     result, created = await resource_factory(gateway)
+    collection = await collection_factory(CONFIG.gateways_collection)
 
     return GatewaysResponseSingle(
         links=ToplevelLinks(next=None),
@@ -101,7 +96,7 @@ async def post_gateways(
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await GATEWAYS_COLLECTION.acount(),
+            data_available=await collection.acount(),
             more_data_available=False,
             **{f"_{CONFIG.provider.prefix}_created": created},
         ),
@@ -122,10 +117,8 @@ async def get_gateway(request: Request, gateway_id: str) -> GatewaysResponseSing
 
     Return a single [`GatewayResource`][optimade_gateway.models.gateways.GatewayResource].
     """
-    from optimade.server.routers.utils import meta_values
-    from optimade_gateway.routers.utils import get_valid_resource
-
-    result = await get_valid_resource(GATEWAYS_COLLECTION, gateway_id)
+    collection = await collection_factory(CONFIG.gateways_collection)
+    result = await get_valid_resource(collection, gateway_id)
 
     return GatewaysResponseSingle(
         links=ToplevelLinks(next=None),
@@ -133,7 +126,7 @@ async def get_gateway(request: Request, gateway_id: str) -> GatewaysResponseSing
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await GATEWAYS_COLLECTION.acount(),
+            data_available=await collection.acount(),
             more_data_available=False,
         ),
     )

--- a/optimade_gateway/routers/gateways.py
+++ b/optimade_gateway/routers/gateways.py
@@ -101,7 +101,7 @@ async def post_gateways(
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await GATEWAYS_COLLECTION.count(),
+            data_available=await GATEWAYS_COLLECTION.acount(),
             more_data_available=False,
             **{f"_{CONFIG.provider.prefix}_created": created},
         ),
@@ -133,7 +133,7 @@ async def get_gateway(request: Request, gateway_id: str) -> GatewaysResponseSing
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await GATEWAYS_COLLECTION.count(),
+            data_available=await GATEWAYS_COLLECTION.acount(),
             more_data_available=False,
         ),
     )

--- a/optimade_gateway/routers/info.py
+++ b/optimade_gateway/routers/info.py
@@ -6,19 +6,24 @@ This file describes the router for:
 
 where, `entry` may be left out.
 """
+# pylint: disable=import-outside-toplevel
 from fastapi import APIRouter, Request
 from optimade import __api_version__
 from optimade.models import (
     BaseInfoAttributes,
     BaseInfoResource,
+    EntryInfoResource,
     EntryInfoResponse,
     InfoResponse,
     LinksResource,
 )
+from optimade.server.exceptions import NotFound
 from optimade.server.routers.utils import get_base_url, meta_values
 from optimade.server.schemas import ERROR_RESPONSES
 
 from optimade_gateway.models import GatewayResource, QueryResource
+from optimade_gateway.routers.utils import aretrieve_queryable_properties
+
 
 ROUTER = APIRouter(redirect_slashes=True)
 
@@ -51,7 +56,10 @@ async def get_info(request: Request) -> InfoResponse:
                 api_version=__api_version__,
                 available_api_versions=[
                     {
-                        "url": f"{get_base_url(request.url)}/v{__api_version__.split('.')[0]}",
+                        "url": (
+                            f"{get_base_url(request.url)}"
+                            f"/v{__api_version__.split('.', maxsplit=1)[0]}"
+                        ),
                         "version": __api_version__,
                     }
                 ],
@@ -94,11 +102,6 @@ async def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
 
     Get information about the gateway service's entry-listing endpoints.
     """
-    from optimade.models import EntryInfoResource
-    from optimade.server.exceptions import NotFound
-
-    from optimade_gateway.routers.utils import aretrieve_queryable_properties
-
     valid_entry_info_endpoints = ENTRY_INFO_SCHEMAS.keys()
     if entry not in valid_entry_info_endpoints:
         raise NotFound(

--- a/optimade_gateway/routers/links.py
+++ b/optimade_gateway/routers/links.py
@@ -7,22 +7,15 @@ This file describes the router for:
 """
 from fastapi import APIRouter, Depends, Request
 
-from optimade.models import LinksResponse, LinksResource
+from optimade.models import LinksResponse
 from optimade.server.query_params import EntryListingQueryParams
 from optimade.server.schemas import ERROR_RESPONSES
 
 from optimade_gateway.common.config import CONFIG
-from optimade_gateway.mappers.links import LinksMapper
-from optimade_gateway.mongo.collection import AsyncMongoCollection
-from optimade_gateway.routers.utils import get_entries
+from optimade_gateway.routers.utils import collection_factory, get_entries
+
 
 ROUTER = APIRouter(redirect_slashes=True)
-
-LINKS_COLLECTION = AsyncMongoCollection(
-    name=CONFIG.links_collection,
-    resource_cls=LinksResource,
-    resource_mapper=LinksMapper,
-)
 
 
 @ROUTER.get(
@@ -42,7 +35,7 @@ async def get_links(
     Return a regular `/links` response for an OPTIMADE implementation.
     """
     return await get_entries(
-        collection=LINKS_COLLECTION,
+        collection=await collection_factory(CONFIG.links_collection),
         response_cls=LinksResponse,
         request=request,
         params=params,

--- a/optimade_gateway/routers/queries.py
+++ b/optimade_gateway/routers/queries.py
@@ -102,7 +102,7 @@ async def post_queries(
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await QUERIES_COLLECTION.count(),
+            data_available=await QUERIES_COLLECTION.acount(),
             more_data_available=False,
             **{f"_{CONFIG.provider.prefix}_created": created},
         ),
@@ -151,7 +151,7 @@ async def get_query(
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await QUERIES_COLLECTION.count(),
+            data_available=await QUERIES_COLLECTION.acount(),
             more_data_available=False,
         ),
     )

--- a/optimade_gateway/routers/queries.py
+++ b/optimade_gateway/routers/queries.py
@@ -85,7 +85,7 @@ async def post_queries(
 
     Create or return existing gateway query according to `query`.
     """
-    from optimade_gateway.queries import perform_query
+    from optimade_gateway.queries.perform import perform_query
     from optimade_gateway.routers.gateways import GATEWAYS_COLLECTION
     from optimade_gateway.routers.utils import resource_factory, validate_resource
 

--- a/optimade_gateway/routers/queries.py
+++ b/optimade_gateway/routers/queries.py
@@ -131,7 +131,7 @@ async def get_query(
 
     query: QueryResource = await get_valid_resource(QUERIES_COLLECTION, query_id)
 
-    if query.attributes.response.errors:
+    if query.attributes.response and query.attributes.response.errors:
         for error in query.attributes.response.errors:
             if error.status:
                 for part in error.status.split(" "):

--- a/optimade_gateway/routers/search.py
+++ b/optimade_gateway/routers/search.py
@@ -43,7 +43,7 @@ from optimade_gateway.models.queries import (
     OptimadeQueryParameters,
     QueryState,
 )
-from optimade_gateway.queries import perform_query, SearchQueryParams
+from optimade_gateway.queries.params import SearchQueryParams
 
 
 ROUTER = APIRouter(redirect_slashes=True)
@@ -73,9 +73,9 @@ async def post_search(request: Request, search: Search) -> QueriesResponseSingle
         [`QueriesResponseSingle`][optimade_gateway.models.responses.QueriesResponseSingle]
 
     """
+    from optimade_gateway.queries.perform import perform_query
     from optimade_gateway.routers.databases import DATABASES_COLLECTION
     from optimade_gateway.routers.queries import QUERIES_COLLECTION
-    from optimade_gateway.routers.utils import resource_factory
 
     # NOTE: It may be that the final list of base URLs (`base_urls`) contains the same provider(s),
     # but with differring base URLS, if, for example, a versioned base URL is supplied.

--- a/optimade_gateway/routers/search.py
+++ b/optimade_gateway/routers/search.py
@@ -76,6 +76,7 @@ async def post_search(request: Request, search: Search) -> QueriesResponseSingle
     from optimade_gateway.queries.perform import perform_query
     from optimade_gateway.routers.databases import DATABASES_COLLECTION
     from optimade_gateway.routers.queries import QUERIES_COLLECTION
+    from optimade_gateway.routers.utils import resource_factory
 
     # NOTE: It may be that the final list of base URLs (`base_urls`) contains the same provider(s),
     # but with differring base URLS, if, for example, a versioned base URL is supplied.
@@ -186,7 +187,7 @@ async def post_search(request: Request, search: Search) -> QueriesResponseSingle
         meta=meta_values(
             url=request.url,
             data_returned=1,
-            data_available=await QUERIES_COLLECTION.count(),
+            data_available=await QUERIES_COLLECTION.acount(),
             more_data_available=False,
             **{f"_{CONFIG.provider.prefix}_created": created},
         ),
@@ -299,7 +300,7 @@ async def get_search(
                 meta=meta_values(
                     url=request.url,
                     data_returned=1,
-                    data_available=await QUERIES_COLLECTION.count(),
+                    data_available=await QUERIES_COLLECTION.acount(),
                     more_data_available=False,
                 ),
             )

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -43,7 +43,7 @@ async def get_entries(
         more_data_available,
         fields,
         include_fields,
-    ) = await collection.find(params=params)
+    ) = await collection.afind(params=params)
 
     if more_data_available:
         # Deduce the `next` link from the current request
@@ -65,7 +65,7 @@ async def get_entries(
         meta=meta_values(
             url=request.url,
             data_returned=data_returned,
-            data_available=await collection.count(),
+            data_available=await collection.acount(),
             more_data_available=more_data_available,
         ),
     )
@@ -243,7 +243,7 @@ async def resource_factory(
             f"{type(create_resource)!r}"
         )
 
-    result, data_returned, more_data_available, _, _ = await RESOURCE_COLLECTION.find(
+    result, data_returned, more_data_available, _, _ = await RESOURCE_COLLECTION.afind(
         criteria={"filter": await clean_python_types(mongo_query)}
     )
 

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for all routers."""
 # pylint: disable=line-too-long,import-outside-toplevel
+from os import getenv
 from typing import TYPE_CHECKING
 import urllib.parse
 
@@ -25,7 +26,8 @@ from optimade_gateway.models import (
 )
 from optimade_gateway.mongo.collection import AsyncMongoCollection
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Dict, Iterable, Tuple, Union
 
     from fastapi import Request

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -26,7 +26,7 @@ from optimade_gateway.models import (
 )
 from optimade_gateway.mongo.collection import AsyncMongoCollection
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import,ungrouped-imports
     from typing import Any, Dict, Iterable, Tuple, Union
 

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -1,4 +1,5 @@
-"""Utility functions for all routers"""
+"""Utility functions for all routers."""
+# pylint: disable=line-too-long,import-outside-toplevel
 from typing import TYPE_CHECKING
 import urllib.parse
 
@@ -10,14 +11,19 @@ from optimade.server.routers.utils import (
     handle_response_fields,
     meta_values,
 )
+from optimade.server.schemas import retrieve_queryable_properties
 
+from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.exceptions import OptimadeGatewayError
 from optimade_gateway.common.logger import LOGGER
+from optimade_gateway.common.utils import clean_python_types, get_resource_attribute
 from optimade_gateway.models import (
     DatabaseCreate,
     GatewayCreate,
     QueryCreate,
+    QueryState,
 )
+from optimade_gateway.mongo.collection import AsyncMongoCollection
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, Tuple, Union
@@ -27,11 +33,14 @@ if TYPE_CHECKING:
     from optimade.server.query_params import EntryListingQueryParams
 
     from optimade_gateway.models import GatewayResource, QueryResource
-    from optimade_gateway.mongo.collection import AsyncMongoCollection
+
+
+COLLECTIONS: "Dict[str, AsyncMongoCollection]" = {}
+"""A lazy-loaded dictionary of asynchronous MongoDB entry-endpoint collections."""
 
 
 async def get_entries(
-    collection: "AsyncMongoCollection",
+    collection: AsyncMongoCollection,
     response_cls: "EntryResponseMany",
     request: "Request",
     params: "EntryListingQueryParams",
@@ -79,8 +88,8 @@ async def aretrieve_queryable_properties(
     Reference to the function in the `optimade` API documentation:
     [`retrieve_queryable_properties()`](https://www.optimade.org/optimade-python-tools/api_reference/server/schemas/#optimade.server.schemas.retrieve_queryable_properties).
 
-    Recursively loops through the schema of a pydantic model and resolves all references, returning
-    a dictionary of all the OPTIMADE-queryable properties of that model.
+    Recursively loops through the schema of a pydantic model and resolves all references,
+    returning a dictionary of all the OPTIMADE-queryable properties of that model.
 
     Parameters:
         schema: The schema of the pydantic model.
@@ -91,15 +100,13 @@ async def aretrieve_queryable_properties(
         sortability, support level, queryability and type, where provided.
 
     """
-    from optimade.server.schemas import retrieve_queryable_properties
-
     return retrieve_queryable_properties(
         schema=schema,
         queryable_properties=queryable_properties,
     )
 
 
-async def validate_resource(collection: "AsyncMongoCollection", entry_id: str) -> None:
+async def validate_resource(collection: AsyncMongoCollection, entry_id: str) -> None:
     """Validate whether a resource exists in a collection"""
     if not await collection.exists(entry_id):
         raise NotFound(
@@ -108,23 +115,22 @@ async def validate_resource(collection: "AsyncMongoCollection", entry_id: str) -
 
 
 async def get_valid_resource(
-    collection: "AsyncMongoCollection", entry_id: str
+    collection: AsyncMongoCollection, entry_id: str
 ) -> "EntryResource":
     """Validate and retrieve a resource"""
-    from optimade_gateway.routers.utils import validate_resource
-
     await validate_resource(collection, entry_id)
     return await collection.get_one(filter={"id": entry_id})
 
 
-async def resource_factory(
+async def resource_factory(  # pylint: disable=too-many-branches
     create_resource: "Union[DatabaseCreate, GatewayCreate, QueryCreate]",
 ) -> "Tuple[Union[LinksResource, GatewayResource, QueryResource], bool]":
     """Get or create a resource
 
     Currently supported resources:
 
-    - `"databases"` ([`DatabaseCreate`][optimade_gateway.models.databases.DatabaseCreate] ->
+    - `"databases"` ([`DatabaseCreate`][optimade_gateway.models.databases.DatabaseCreate]
+        ->
         [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource))
     - `"gateways"` ([`GatewayCreate`][optimade_gateway.models.gateways.GatewayCreate] ->
         [`GatewayResource`][optimade_gateway.models.gateways.GatewayResource])
@@ -141,28 +147,31 @@ async def resource_factory(
         model, the `base_url.href` value is used to query the MongoDB.
 
     === "Gateways"
-        The collected list of `databases.attributes.base_url` values is considered unique across
-        all gateways.
+        The collected list of `databases.attributes.base_url` values is considered unique
+        across all gateways.
 
-        In the database, the search is done as a combination of the length/size of the `databases`'
-        Python list/MongoDB array and a match on all (using the MongoDB `$all` operator) of the
+        In the database, the search is done as a combination of the length/size of the
+        `databases`' Python list/MongoDB array and a match on all (using the MongoDB
+        `$all` operator) of the
         [`databases.attributes.base_url`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResourceAttributes.base_url)
         element values, when compared with the `create_resource`.
 
         !!! important
-            The `database_ids` attribute **must not** contain values that are not also included in the
-            `databases` attribute, in the form of the IDs for the individual databases.
-            If this should be the case an
-            [`OptimadeGatewayError`][optimade_gateway.common.exceptions.OptimadeGatewayError] will be
-            thrown.
+            The `database_ids` attribute **must not** contain values that are not also
+            included in the `databases` attribute, in the form of the IDs for the
+            individual databases. If this should be the case an
+            [`OptimadeGatewayError`][optimade_gateway.common.exceptions.OptimadeGatewayError]
+            will be thrown.
 
     === "Queries"
-        The `gateway_id`, `query_parameters`, and `endpoint` fields are collectively considered to
-        define uniqueness for a [`QueryResource`][optimade_gateway.models.queries.QueryResource]
-        in the MongoDB collection.
+        The `gateway_id`, `query_parameters`, and `endpoint` fields are collectively
+        considered to define uniqueness for a
+        [`QueryResource`][optimade_gateway.models.queries.QueryResource] in the MongoDB
+        collection.
 
         !!! attention
-            Only the `/structures` entry endpoint can be queried with multiple expected responses.
+            Only the `/structures` entry endpoint can be queried with multiple expected
+            responses.
 
             This means the `endpoint` field defaults to `"structures"`, i.e., the
             [`StructureResource`](https://www.optimade.org/optimade-python-tools/all_models/#optimade.models.structures.StructureResource)
@@ -174,20 +183,17 @@ async def resource_factory(
     Returns:
         Two things in a tuple:
 
-        - Either a [`GatewayResource`][optimade_gateway.models.gateways.GatewayResource]; a
-            [`QueryResource`][optimade_gateway.models.queries.QueryResource]; or a
-            [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource) and
+        - Either a [`GatewayResource`][optimade_gateway.models.gateways.GatewayResource];
+            a [`QueryResource`][optimade_gateway.models.queries.QueryResource]; or a
+            [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource)
+            and
         - whether or not the resource was newly created.
 
     """
-    from optimade_gateway.common.utils import clean_python_types, get_resource_attribute
-
     created = False
 
     if isinstance(create_resource, DatabaseCreate):
-        from optimade_gateway.routers.databases import (  # type: ignore[no-redef]
-            DATABASES_COLLECTION as RESOURCE_COLLECTION,
-        )
+        collection_name = CONFIG.databases_collection
 
         base_url = get_resource_attribute(create_resource, "base_url")
 
@@ -198,9 +204,7 @@ async def resource_factory(
             ]
         }
     elif isinstance(create_resource, GatewayCreate):
-        from optimade_gateway.routers.gateways import (  # type: ignore[no-redef]
-            GATEWAYS_COLLECTION as RESOURCE_COLLECTION,
-        )
+        collection_name = CONFIG.gateways_collection
 
         # One MUST have taken care of database_ids prior to calling `resource_factory()`
         database_attr_ids = {_.id for _ in create_resource.databases or []}
@@ -211,8 +215,8 @@ async def resource_factory(
         }
         if unknown_ids:
             raise OptimadeGatewayError(
-                "When using `resource_factory()` for `GatewayCreate`, `database_ids` MUST not "
-                f"include unknown IDs. Passed unknown IDs: {unknown_ids}"
+                "When using `resource_factory()` for `GatewayCreate`, `database_ids` MUST"
+                f" not include unknown IDs. Passed unknown IDs: {unknown_ids}"
             )
 
         mongo_query = {
@@ -222,12 +226,10 @@ async def resource_factory(
             },
         }
     elif isinstance(create_resource, QueryCreate):
-        from optimade_gateway.models.queries import QueryState
-        from optimade_gateway.routers.queries import (  # type: ignore[no-redef]
-            QUERIES_COLLECTION as RESOURCE_COLLECTION,
-        )
+        collection_name = CONFIG.queries_collection
 
-        # Currently only /structures entry endpoints can be queried with multiple expected responses.
+        # Currently only /structures entry endpoints can be queried with multiple
+        # expected responses.
         create_resource.endpoint = (
             create_resource.endpoint if create_resource.endpoint else "structures"
         )
@@ -243,21 +245,22 @@ async def resource_factory(
             f"{type(create_resource)!r}"
         )
 
-    result, data_returned, more_data_available, _, _ = await RESOURCE_COLLECTION.afind(
+    collection = await collection_factory(collection_name)
+    result, data_returned, more_data_available, _, _ = await collection.afind(
         criteria={"filter": await clean_python_types(mongo_query)}
     )
 
     if more_data_available:
         raise OptimadeGatewayError(
-            "more_data_available MUST be False for a single entry response, however it is "
-            f"{more_data_available}"
+            "more_data_available MUST be False for a single entry response, however it "
+            f"is {more_data_available}"
         )
 
     if result:
         if data_returned > 1:
             raise OptimadeGatewayError(
-                f"More than one {result[0].type} were found. IDs of found {result[0].type}: "
-                f"{[_.id for _ in result]}"
+                f"More than one {result[0].type} were found. IDs of found "
+                f"{result[0].type}: {[_.id for _ in result]}"
             )
         if isinstance(result, list):
             result = result[0]
@@ -265,7 +268,10 @@ async def resource_factory(
         if isinstance(create_resource, DatabaseCreate):
             # Set required `LinksResourceAttributes` values if not set
             if not create_resource.description:
-                create_resource.description = f"{create_resource.name} created by OPTIMADE gateway database registration."
+                create_resource.description = (
+                    f"{create_resource.name} created by OPTIMADE gateway database "
+                    "registration."
+                )
             if not create_resource.link_type:
                 create_resource.link_type = LinkType.EXTERNAL
             if not create_resource.homepage:
@@ -277,8 +283,54 @@ async def resource_factory(
                 create_resource.__fields_set__.remove("database_ids")
         elif isinstance(create_resource, QueryCreate):
             create_resource.state = QueryState.CREATED
-        result = await RESOURCE_COLLECTION.create_one(create_resource)
+        result = await collection.create_one(create_resource)
         LOGGER.debug("Created new %s: %r", result.type, result)
         created = True
 
     return result, created
+
+
+async def collection_factory(name: str) -> AsyncMongoCollection:
+    """Get or initiate an entry-endpoint resource collection.
+
+    This factory utilizes the global dictionary
+    [`COLLECTIONS`][optimade_gateway.routers.utils.COLLECTIONS].
+    It lazily instantiates the collections and then caches them in the dictionary.
+
+    Parameters:
+        name: The configured name for the entry-endpoint resource collection.
+
+    Returns:
+        The OPTIMADE Gateway asynchronous implementation of the
+        [`MongoCollection`](https://www.optimade.org/optimade-python-tools/api_reference/server/entry_collections/mongo/#optimade.server.entry_collections.mongo.MongoCollection).
+
+    Raises:
+        ValueError: If the supplied `name` is not one of the configured valid collection
+            names.
+
+    """
+    if name in COLLECTIONS:
+        return COLLECTIONS[name]
+
+    if name == CONFIG.databases_collection:
+        from optimade_gateway.mappers.databases import DatabasesMapper as ResourceMapper  # type: ignore[no-redef]
+    elif name == CONFIG.gateways_collection:
+        from optimade_gateway.mappers.gateways import GatewaysMapper as ResourceMapper  # type: ignore[no-redef]
+    elif name == CONFIG.queries_collection:
+        from optimade_gateway.mappers.queries import QueryMapper as ResourceMapper  # type: ignore[no-redef]
+    elif name == CONFIG.links_collection:
+        from optimade_gateway.mappers.links import LinksMapper as ResourceMapper  # type: ignore[no-redef]
+    else:
+        raise ValueError(
+            f"{name!r} is not a valid entry-endpoint resource collection name. Configured"
+            " valid names: "
+            f"{(CONFIG.databases_collection, CONFIG.gateways_collection, CONFIG.queries_collection, CONFIG.links_collection)}"
+        )
+
+    COLLECTIONS[name] = AsyncMongoCollection(
+        name=name,
+        resource_cls=ResourceMapper.ENTRY_RESOURCE_CLASS,
+        resource_mapper=ResourceMapper,
+    )
+
+    return COLLECTIONS[name]

--- a/optimade_gateway/run.py
+++ b/optimade_gateway/run.py
@@ -1,3 +1,4 @@
+"""Simplified function for running the server used in the CLI."""
 import argparse
 import os
 from pathlib import Path
@@ -32,7 +33,8 @@ def run(argv: "Optional[Sequence[Text]]" = None) -> None:
 
     if args.prod:
         print(
-            "Consider running the gateway using Docker or the `uvicorn` CLI directly instead!"
+            "Consider running the gateway using Docker or the `uvicorn` CLI directly "
+            "instead!"
         )
         uvicorn_kwargs.update({"reload": False, "log_level": "info"})
     else:

--- a/optimade_gateway/run.py
+++ b/optimade_gateway/run.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 
 import uvicorn
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+    # pylint: disable=unused-import
     from typing import Optional, Sequence, Text
 
 

--- a/optimade_gateway/run.py
+++ b/optimade_gateway/run.py
@@ -1,12 +1,15 @@
 import argparse
 import os
 from pathlib import Path
-from typing import Sequence, Text
+from typing import TYPE_CHECKING
 
 import uvicorn
 
+if TYPE_CHECKING:
+    from typing import Optional, Sequence, Text
 
-def run(argv: Sequence[Text] = None) -> None:
+
+def run(argv: "Optional[Sequence[Text]]" = None) -> None:
     """Run OPTIMADE Gateway REST API server."""
     parser = argparse.ArgumentParser(
         "optimade-gateway",

--- a/optimade_gateway/run.py
+++ b/optimade_gateway/run.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import uvicorn
 
-if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):
+if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     # pylint: disable=unused-import
     from typing import Optional, Sequence, Text
 

--- a/optimade_gateway/warnings.py
+++ b/optimade_gateway/warnings.py
@@ -1,14 +1,16 @@
-"""Server warnings
+"""Server warnings.
 
-The warnings in this module will all be caught by middleware and added to the response under
-`meta.warnings`.
+The warnings in this module will all be caught by middleware and added to the response
+under `meta.warnings`.
 """
 from optimade.server.warnings import OptimadeWarning
 
 
 class OptimadeGatewayWarning(OptimadeWarning):
-    """Base Warning for the `optimade-gateway` package"""
+    """Base Warning for the `optimade-gateway` package."""
 
 
 class SortNotSupported(OptimadeGatewayWarning):
-    """Sorting (the `sort` query parameter) is currently not supported for gateway queries to external OPTIMADE databases. See https://optimade.org/optimade-gateway#sorting for more information."""
+    """Sorting (the `sort` query parameter) is currently not supported for gateway
+    queries to external OPTIMADE databases. See
+    https://optimade.org/optimade-gateway#sorting for more information."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,6 @@ allow_redefinition = true
 max-line-length = 90
 disable = [
     "duplicate-code",
-    "no-name-in-module"
+    "no-name-in-module",
+    "import-error"
 ]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,11 @@ disable = [
     "duplicate-code",
     "no-name-in-module"
 ]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+required_plugins = "pytest-asyncio>=0.15.0 pytest-cov>=2.11 pytest-httpx>=0.13.0"
+addopts = "-rs --cov=./optimade_gateway/ --cov-report=term --durations=10"
+filterwarnings = [
+    "ignore:.*imp module.*:DeprecationWarning"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.mypy]
+python_version = "3.8"
+ignore_missing_imports = true
+scripts_are_modules = true
+warn_unused_configs = true
+show_error_codes = true
+allow_redefinition = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,11 @@ scripts_are_modules = true
 warn_unused_configs = true
 show_error_codes = true
 allow_redefinition = true
+
+[tool.pylint.messages_control]
+max-line-length = 90
+disable = [
+    "duplicate-code",
+    "no-name-in-module"
+]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,5 @@ allow_redefinition = true
 max-line-length = 90
 disable = [
     "duplicate-code",
-    "no-name-in-module",
-    "import-error"
+    "no-name-in-module"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ disable = [
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-required_plugins = "pytest-asyncio>=0.15.0 pytest-cov>=2.11 pytest-httpx>=0.13.0"
+required_plugins = "pytest-asyncio>=0.15.1 pytest-cov>=2.12 pytest-httpx>=0.13.0"
 addopts = "-rs --cov=./optimade_gateway/ --cov-report=term --durations=10"
 filterwarnings = [
     "ignore:.*imp module.*:DeprecationWarning"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 invoke~=1.6
 pre-commit~=2.15
-pylint~=2.10
 pytest~=6.2
 pytest-asyncio~=0.15.1
 pytest-cov~=2.12

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 invoke~=1.6
 pre-commit~=2.15
+pylint~=2.10
 pytest~=6.2
 pytest-asyncio~=0.15.1
 pytest-cov~=2.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[tool:pytest]
-minversion = 6.0
-required_plugins = pytest-asyncio>=0.15.0,<0.16.0 pytest-cov>=2.11,<3.0 pytest-httpx>=0.13.0,<0.14.0
-addopts = -rs --cov=./optimade_gateway/ --cov-report=term --durations=10
-filterwarnings =
-    ignore:.*imp module.*:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[flake8]
-ignore =
-    # Line to long. Handled by black.
-    E501
-    # Line break before binary operator. This is preferred formatting for black.
-    W503
-    # Whitespace before ':'
-    E203
-
 [tool:pytest]
 minversion = 6.0
 required_plugins = pytest-asyncio>=0.15.0,<0.16.0 pytest-cov>=2.11,<3.0 pytest-httpx>=0.13.0,<0.14.0

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+"""Setup instructions and metadata for `pip install`."""
 from pathlib import Path
 import re
 
@@ -6,7 +7,7 @@ from setuptools import setup, find_packages
 
 TOP_DIR = Path(__file__).parent.resolve()
 
-with open(TOP_DIR / "optimade_gateway/__init__.py", "r") as handle:
+with open(TOP_DIR / "optimade_gateway/__init__.py", "r", encoding="utf8") as handle:
     VERSION = AUTHOR = AUTHOR_EMAIL = None
     for line in handle.readlines():
         VERSION_match = re.match(r'__version__ = "(?P<version>.+)"', line)
@@ -27,27 +28,28 @@ with open(TOP_DIR / "optimade_gateway/__init__.py", "r") as handle:
     }.items():
         if value is None:
             raise RuntimeError(
-                f"Could not determine {info} from {TOP_DIR / 'optimade_gateway/__init__.py'} !"
+                f"Could not determine {info} from "
+                f"{TOP_DIR / 'optimade_gateway/__init__.py'} !"
             )
-    VERSION = VERSION.group("version")
-    AUTHOR = AUTHOR.group("author")
-    AUTHOR_EMAIL = AUTHOR_EMAIL.group("email")
+    VERSION = VERSION.group("version")  # type: ignore[union-attr]
+    AUTHOR = AUTHOR.group("author")  # type: ignore[union-attr]
+    AUTHOR_EMAIL = AUTHOR_EMAIL.group("email")  # type: ignore[union-attr]
 
-with open(TOP_DIR / "requirements.txt", "r") as handle:
+with open(TOP_DIR / "requirements.txt", "r", encoding="utf8") as handle:
     BASE = [
         f"{_.strip()}"
         for _ in handle.readlines()
         if not _.startswith("#") and "git+" not in _
     ]
 
-with open(TOP_DIR / "requirements_docs.txt", "r") as handle:
+with open(TOP_DIR / "requirements_docs.txt", "r", encoding="utf8") as handle:
     DOCS = [
         f"{_.strip()}"
         for _ in handle.readlines()
         if not _.startswith("#") and "git+" not in _
     ]
 
-with open(TOP_DIR / "requirements_dev.txt", "r") as handle:
+with open(TOP_DIR / "requirements_dev.txt", "r", encoding="utf8") as handle:
     DEV = [
         f"{_.strip()}"
         for _ in handle.readlines()

--- a/tasks.py
+++ b/tasks.py
@@ -1,3 +1,8 @@
+"""Repository management tasks powered by `invoke`.
+
+More information on `invoke` can be found at http://www.pyinvoke.org/.
+"""
+# pylint: disable=import-outside-toplevel,too-many-locals
 import re
 import sys
 from typing import Tuple
@@ -11,12 +16,12 @@ TOP_DIR = Path(__file__).parent.resolve()
 
 def update_file(filename: str, sub_line: Tuple[str, str], strip: str = None) -> None:
     """Utility function for tasks to read, update, and write files"""
-    with open(filename, "r") as handle:
+    with open(filename, "r", encoding="utf8") as handle:
         lines = [
             re.sub(sub_line[0], sub_line[1], line.rstrip(strip)) for line in handle
         ]
 
-    with open(filename, "w") as handle:
+    with open(filename, "w", encoding="utf8") as handle:
         handle.write("\n".join(lines))
         handle.write("\n")
 
@@ -34,7 +39,9 @@ def setver(_, ver=""):
     )
     if not match:
         sys.exit(
-            "Error: Please specify version as 'Major.Minor.Patch(-Pre-Release+Build Metadata)' or 'vMajor.Minor.Patch(-Pre-Release+Build Metadata)'"
+            "Error: Please specify version as "
+            "'Major.Minor.Patch(-Pre-Release+Build Metadata)' or "
+            "'vMajor.Minor.Patch(-Pre-Release+Build Metadata)'"
         )
     ver = match.group("version")
 
@@ -67,13 +74,13 @@ def create_api_reference_docs(_, pre_clean=False):
     def write_file(full_path: Path, content: str) -> None:
         """Write file with `content` to `full_path`"""
         if full_path.exists():
-            with open(full_path, "r") as handle:
+            with open(full_path, "r", encoding="utf8") as handle:
                 cached_content = handle.read()
             if content == cached_content:
                 del cached_content
                 return
             del cached_content
-        with open(full_path, "w") as handle:
+        with open(full_path, "w", encoding="utf8") as handle:
             handle.write(content)
 
     package_dir = TOP_DIR / "optimade_gateway"
@@ -112,7 +119,9 @@ def create_api_reference_docs(_, pre_clean=False):
         else:
             write_file(
                 full_path=docs_sub_dir / ".pages",
-                content=pages_template.format(name=str(relpath).split("/")[-1]),
+                content=pages_template.format(
+                    name=str(relpath).rsplit("/", maxsplit=1)[-1]
+                ),
             )
 
         # Create markdown files
@@ -133,7 +142,8 @@ def create_api_reference_docs(_, pre_clean=False):
             )
             md_filename = filename.replace(".py", ".md")
 
-            # For models we want to include EVERYTHING, even if it doesn't have a doc-string
+            # For models we want to include EVERYTHING, even if it doesn't have a
+            # doc-string
             template = models_template if str(relpath) == "models" else md_template
 
             write_file(
@@ -148,7 +158,7 @@ def create_docs_index(_):
     readme = TOP_DIR / "README.md"
     docs_index = TOP_DIR / "docs/index.md"
 
-    with open(readme) as handle:
+    with open(readme, encoding="utf8") as handle:
         content = handle.read()
 
     replacement_mapping = [
@@ -159,5 +169,5 @@ def create_docs_index(_):
     for old, new in replacement_mapping:
         content = content.replace(old, new)
 
-    with open(docs_index, "w") as handle:
+    with open(docs_index, "w", encoding="utf8") as handle:
         handle.write(content)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """Pytest fixtures and configuration for all tests"""
-# pylint: disable=import-error
 import asyncio
 import json
 import os

--- a/tests/routers/test_databases.py
+++ b/tests/routers/test_databases.py
@@ -1,5 +1,5 @@
 """Tests for /databases endpoints"""
-# pylint: disable=import-error,no-name-in-module
+# pylint: disable=no-name-in-module
 from pathlib import Path
 from typing import Awaitable, Callable
 

--- a/tests/routers/test_gateways.py
+++ b/tests/routers/test_gateways.py
@@ -1,5 +1,5 @@
 """Tests for /gateways endpoints"""
-# pylint: disable=import-error,no-name-in-module
+# pylint: disable=no-name-in-module
 from pathlib import Path
 from typing import Awaitable, Callable
 

--- a/tests/routers/test_queries.py
+++ b/tests/routers/test_queries.py
@@ -1,5 +1,5 @@
 """Tests for /queries endpoints"""
-# pylint: disable=import-error,no-name-in-module
+# pylint: disable=no-name-in-module
 import json
 from pathlib import Path
 from typing import Awaitable, Callable

--- a/tests/routers/test_queries.py
+++ b/tests/routers/test_queries.py
@@ -117,7 +117,8 @@ async def test_post_queries_bad_data(
     """Test POST /queries with bad data"""
     from optimade.models import ErrorResponse, OptimadeError
 
-    from optimade_gateway.routers.gateways import GATEWAYS_COLLECTION
+    from optimade_gateway.common.config import CONFIG
+    from optimade_gateway.routers.utils import collection_factory
 
     data = {
         "gateway_id": "non-existent",
@@ -139,7 +140,10 @@ async def test_post_queries_bad_data(
         == OptimadeError(
             title="Not Found",
             status="404",
-            detail=f"Resource <id=non-existent> not found in {GATEWAYS_COLLECTION}.",
+            detail=(
+                "Resource <id=non-existent> not found in "
+                f"{await collection_factory(CONFIG.gateways_collection)}."
+            ),
         ).dict()
     )
 


### PR DESCRIPTION
Update help tools to use `bandit` (security), `pylint` (linting), `safety` (dependency security), and `mypy` (type-checking).
Remove use of `flake8` (linting), since `pylint` will take this place instead.

So far this has resulted in:
- Removing some unnecessary imports unless there's type checking.
- Remove entry-endpoint resource collection initialization to a factory function and lazily initialize and cache them in a global dictionary - this has optimized an issue with circular imports.
- Remove use of `assert` statements in non-test code (these commands can be circumvented by running python with the "optimize" flag (`-O`)).

Missing:
Implement and satisfy:
- [X] `bandit`
- [X] `pylint`
- [x] `safety`
- [X] `mypy`