### PR TITLE
Only update permanent dependabot branch after CI

### DIFF
--- a/.github/workflows/ci_dependabot_branch.yml
+++ b/.github/workflows/ci_dependabot_branch.yml
@@ -1,14 +1,15 @@
 name: CI - Keep dependabot branch up-to-date
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI - Tests"]
     branches: [main]
+    types: [completed]
 
 env:
   DEPENDABOT_BRANCH: ci/dependabot-updates
   GIT_USER_NAME: OPTIMADE Developers
   GIT_USER_EMAIL: "dev@optimade.org"
-
 
 jobs:
 


### PR DESCRIPTION
Use the `workflow_run` event to run the `ci_dependabot_branch.yml` workflow.