### PR TITLE
Run dependabot workflow more often

### DIFF
--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # At 8:30 every Monday
     # This matches Dependabot, which runs every Monday (pip) and every day (GH Actions) at 7:00
-    - cron: "30 8 * * 1"
+    - cron: "30 8 * * *"
 
 jobs:
 

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -41,7 +41,6 @@ jobs:
         author: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
         branch: ci/update-dependencies
         delete-branch: true
-        branch-suffix: timestamp
         title: Update dependencies
         body: |
           ### Update dependencies

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -5,9 +5,6 @@ on:
     # At 8:30 every Monday
     # This matches Dependabot, which runs every Monday (pip) and every day (GH Actions) at 7:00
     - cron: "30 8 * * *"
-  push:
-    branches:
-      - run-dependabot-workflow-more-often
 
 jobs:
 

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -5,6 +5,9 @@ on:
     # At 8:30 every Monday
     # This matches Dependabot, which runs every Monday (pip) and every day (GH Actions) at 7:00
     - cron: "30 8 * * *"
+  push:
+    branches:
+      - run-dependabot-workflow-more-often
 
 jobs:
 

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -24,8 +24,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
-        ref: ${{ env.DEPENDABOT_BRANCH }}
+        ref: main
+
+    - name: Reset to '${{ env.DEPENDABOT_BRANCH }}'
+      run: |
+        git fetch origin ${{ env.DEPENDABOT_BRANCH }}:${{ env.DEPENDABOT_BRANCH }}
+        git reset --hard ${{ env.DEPENDABOT_BRANCH }}
 
     - name: Create PR
       id: cpr
@@ -38,7 +42,6 @@ jobs:
         branch: ci/update-dependencies
         delete-branch: true
         branch-suffix: timestamp
-        base: main
         title: Update dependencies
         body: |
           ### Update dependencies
@@ -50,6 +53,5 @@ jobs:
         labels: CI/CD,dependencies
 
     - name: Information
-      if: env.CREATE_PR
       run: 'echo "${{ steps.cpr.outputs.pull-request-operation }} PR #${{ steps.cpr.outputs.pull-request-number }}: ${{ steps.cpr.outputs.pull-request-url }}"'
 

--- a/tasks.py
+++ b/tasks.py
@@ -246,3 +246,6 @@ def update_pytest_reqs(_):
         f"Successfully updated pytest config plugins:\n        {plugins}\n  (was: "
         f"{original_versions})"
     )
+
+
+print("test of workflow")

--- a/tasks.py
+++ b/tasks.py
@@ -246,6 +246,3 @@ def update_pytest_reqs(_):
         f"Successfully updated pytest config plugins:\n        {plugins}\n  (was: "
         f"{original_versions})"
     )
-
-
-print("test of workflow")


### PR DESCRIPTION
Run the dependabot workflow every day, instead of just Monday.

Fix the workflow to create the proper PR.