### PR TITLE
Update cron times

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: "07:00"
+    time: "05:00"
   # Should be bigger than or equal to the total number of dependencies (currently 9)
   open-pull-requests-limit: 15
   target-branch: ci/dependabot-updates
@@ -15,7 +15,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "07:00"
+    time: "05:00"
   target-branch: ci/dependabot-updates
   labels:
   - "CI/CD"

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -2,9 +2,10 @@ name: CI - Single Dependabot PR
 
 on:
   schedule:
-    # At 8:30 every Monday
-    # This matches Dependabot, which runs every Monday (pip) and every day (GH Actions) at 7:00
-    - cron: "30 6 * * *"
+    # At 8:30 every Monday (6:30 UTC)
+    # This matches Dependabot, which runs once a week (every Monday) (pip)
+    # and every day (GH Actions) at 7:00 (5:00 UTC)
+    - cron: "30 6 * * 1"
 
 jobs:
 

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # At 8:30 every Monday
     # This matches Dependabot, which runs every Monday (pip) and every day (GH Actions) at 7:00
-    - cron: "30 8 * * *"
+    - cron: "30 6 * * *"
 
 jobs:
 


### PR DESCRIPTION
Closes #147.

Update cron times to be the desired times, but expressed in UTC.

Only run the "single dependabot update PR" once a week, on Monday.