### PR TITLE
Fix double docs deployment on release

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -35,7 +35,7 @@ jobs:
         pip install -U -e .[dev]
 
     - name: Update changelog
-      uses: CharMixer/auto-changelog-action@v1.4
+      uses: CharMixer/auto-changelog-action@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
@@ -56,7 +56,7 @@ jobs:
       run: echo "PREVIOUS_VERSION=$(git tag -l --sort -version:refname | sed -n 2p)" >> $GITHUB_ENV
 
     - name: Create release-specific changelog
-      uses: CharMixer/auto-changelog-action@v1.4
+      uses: CharMixer/auto-changelog-action@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -130,4 +130,6 @@ jobs:
         git config --global user.email "${{ env.GIT_USER_EMAIL }}"
 
     - name: Deploy documentation
-      run: mike deploy --push --remote origin --branch test-mike --update-aliases --config-file mkdocs.yml ${GITHUB_REF#refs/tags/v} stable
+      run: |
+        mike deploy --push --remote origin --branch test-mike --update-aliases --config-file mkdocs.yml ${GITHUB_REF#refs/tags/v} stable
+        mike deploy --push --remote origin --branch test-mike --update-aliases --config-file mkdocs.yml latest main

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -44,28 +44,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Release check
+      run: |
+        COMMIT_MSG="$(gh api /repos/${{ github.repository}}/commits/main --jq '.commit.message')"
+        if [[ "${COMMIT_MSG}" =~ ^Release\ v.*\ -\ Changelog$ ]]; then
+          # In a release - do not run this job !
+          echo "RELEASE_RUN=true" >> $GITHUB_ENV
+        else
+          echo "RELEASE_RUN=false" >> $GITHUB_ENV
+        fi
+
     - name: Checkout repository
+      if: "! env.RELEASE_RUN"
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
     - name: Set up Python 3.8
+      if: "! env.RELEASE_RUN"
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
     - name: Install dependencies
+      if: "! env.RELEASE_RUN"
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools wheel
         pip install -U -e .[docs]
 
     - name: Set up git user
+      if: "! env.RELEASE_RUN"
       run: |
         git config --global user.name "OPTIMADE Developers"
         git config --global user.email "dev@optimade.org"
 
     - name: Check API Reference and landing page
+      if: "! env.RELEASE_RUN"
       run: |
         invoke create-api-reference-docs --pre-clean
         invoke create-docs-index
@@ -77,4 +92,5 @@ jobs:
         fi
 
     - name: Deploy documentation
+      if: "! env.RELEASE_RUN"
       run: mike deploy --push --remote origin --branch test-mike --update-aliases --config-file mkdocs.yml latest main


### PR DESCRIPTION
Fixes #145 

Check whether the latest commit to `main` has a message that matches the auto-generated commit message during release and update of the changelog.
While this is not a perfect check, it should do.

Deploy the `latest` version of the documentation as part of the release workflow.

Finally, use vMAJOR for the changelog action.