### PR TITLE
Attempt with fetch-depth 0

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -110,7 +110,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 2
+        fetch-depth: 0
         ref: ${{ env.PUBLISH_UPDATE_BRANCH }}
 
     - name: Set up Python 3.8
@@ -131,5 +131,9 @@ jobs:
 
     - name: Deploy documentation
       run: |
+        git fetch origin
+
         mike deploy --push --remote origin --branch test-mike --update-aliases --config-file mkdocs.yml ${GITHUB_REF#refs/tags/v} stable
+
+        git fetch origin
         mike deploy --push --remote origin --branch test-mike --update-aliases --config-file mkdocs.yml latest main


### PR DESCRIPTION
Release docs CD job is still failing - try fetching all history and
doing `git fetch origin` before each `mike deploy` command.