### PR TITLE
Reset `ci/dependabot-updates` branch upon merge to `main`

### DIFF
--- a/.github/utils/single_dependency_pr_body.txt
+++ b/.github/utils/single_dependency_pr_body.txt
@@ -1,0 +1,6 @@
+### Update dependencies
+
+Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
+It should be automagically merged into `main` upon CI success.
+
+For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -23,13 +23,28 @@ jobs:
         ref: ${{ env.DEPENDABOT_BRANCH }}
         fetch-depth: 0
 
-    - name: Update '${{ env.DEPENDABOT_BRANCH }}'
+    - name: Set up git config
       run: |
         git config --global user.name "${{ env.GIT_USER_NAME }}"
         git config --global user.email "${{ env.GIT_USER_EMAIL }}"
 
+    - name: Update '${{ env.DEPENDABOT_BRANCH }}'
+      run: |
         git fetch origin
-        git merge -m "Keep '${{ env.DEPENDABOT_BRANCH }}' up-to-date with 'main'" origin/main
+
+        LATEST_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls -X GET -f state=closed -f per_page=1 -f sort=updated -f direction=desc --jq '.[].body')"
+        if [ "${LATEST_PR_BODY}" == "$(cat .github/utils/single_dependency_pr_body.txt)" ]; then
+          # The dependency branch has just been merged into `main`
+          # The dependency branch should be reset to `main`
+          git reset --hard origin/main
+          echo "FORCE_PUSH=yes" >> $GITHUB_ENV
+        else
+          # Normal procedure: Merge `main` into `ci/dependabot-updates`
+          git merge -m "Keep '${{ env.DEPENDABOT_BRANCH }}' up-to-date with 'main'" origin/main
+          echo "FORCE_PUSH=no" >> $GITHUB_ENV
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push to '${{ env.DEPENDABOT_BRANCH }}'
       uses: CasperWA/push-protected@v2
@@ -37,6 +52,7 @@ jobs:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         branch: ${{ env.DEPENDABOT_BRANCH }}
         sleep: 15
+        force: ${{ env.FORCE_PUSH }}
 
   deploy-docs:
     name: Deploy `latest` documentation

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -29,6 +29,9 @@ jobs:
         git fetch origin ${{ env.DEPENDABOT_BRANCH }}:${{ env.DEPENDABOT_BRANCH }}
         git reset --hard ${{ env.DEPENDABOT_BRANCH }}
 
+    - name: Fetch PR body
+      run: echo "PR_BODY=$(cat .github/utils/single_dependency_pr_body.txt)" >> $GITHUB_ENV
+
     - name: Create PR
       id: cpr
       uses: peter-evans/create-pull-request@v3
@@ -40,13 +43,7 @@ jobs:
         branch: ci/update-dependencies
         delete-branch: true
         title: Update dependencies
-        body: |
-          ### Update dependencies
-
-          Automatically created PR from [`${{ env.DEPENDABOT_BRANCH }}`](https://github.com/Materials-Consortia/optimade-gateway/tree/${{ env.DEPENDABOT_BRANCH }}).
-          It should be automagically merged into `main` upon CI success.
-
-          For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).
+        body: "${{ env.PR_BODY }}"
         labels: CI/CD,dependencies
 
     - name: Information

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -2,10 +2,10 @@ name: CI - Single Dependabot PR
 
 on:
   schedule:
-    # At 8:30 every Monday (6:30 UTC)
-    # This matches Dependabot, which runs once a week (every Monday) (pip)
+    # At 8:30 every Wednesday (6:30 UTC)
+    # Dependabot runs once a week (every Monday) (pip)
     # and every day (GH Actions) at 7:00 (5:00 UTC)
-    - cron: "30 6 * * 1"
+    - cron: "30 6 * * 3"
 
 jobs:
 


### PR DESCRIPTION
Fixes #131 
Closes #160 

When the automatic PR for updating dependencies from `ci/dependabot-updates` to `main` has been performed, the `ci/dependabot-updates` branch will be reset to `main`, instead of having `main` merged into it. This will make for a more readable PR in the future.

Furthermore, the day for creating the dependency PR has been set to Wednesday instead of Monday.