### PR TITLE
Wrap def in quotations and change to single quote

### DIFF
--- a/.github/utils/single_dependency_pr_body.txt
+++ b/.github/utils/single_dependency_pr_body.txt
@@ -1,6 +1,6 @@
 ### Update dependencies
 
-Automatically created PR from [ci/dependabot-updates](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
-It should be automagically merged into main upon CI success.
+Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
+It should be automagically merged into `main` upon CI success.
 
-For more information see the [Dependabot updates workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).
+For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).

--- a/.github/utils/single_dependency_pr_body.txt
+++ b/.github/utils/single_dependency_pr_body.txt
@@ -1,6 +1,6 @@
 ### Update dependencies
 
 Automatically created PR from ['ci/dependabot-updates'](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
-It should be automagically merged into `main` upon CI success.
+It should be automagically merged into 'main' upon CI success.
 
 For more information see the ['Dependabot updates' workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).

--- a/.github/utils/single_dependency_pr_body.txt
+++ b/.github/utils/single_dependency_pr_body.txt
@@ -1,6 +1,6 @@
 ### Update dependencies
 
-Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
+Automatically created PR from ['ci/dependabot-updates'](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
 It should be automagically merged into `main` upon CI success.
 
 For more information see the ['Dependabot updates' workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).

--- a/.github/utils/single_dependency_pr_body.txt
+++ b/.github/utils/single_dependency_pr_body.txt
@@ -3,4 +3,4 @@
 Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
 It should be automagically merged into `main` upon CI success.
 
-For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).
+For more information see the ['Dependabot updates' workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).

--- a/.github/utils/single_dependency_pr_body.txt
+++ b/.github/utils/single_dependency_pr_body.txt
@@ -1,6 +1,6 @@
 ### Update dependencies
 
-Automatically created PR from ['ci/dependabot-updates'](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
-It should be automagically merged into 'main' upon CI success.
+Automatically created PR from [ci/dependabot-updates](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
+It should be automagically merged into main upon CI success.
 
-For more information see the ['Dependabot updates' workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).
+For more information see the [Dependabot updates workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'Materials-Consortia'
     runs-on: ubuntu-latest
     env:
-      DEPENDABOT_BRANCH: ci/dependabot-updates
+      DEPENDABOT_BRANCH: fix-167-single-dependabot-pr
       GIT_USER_NAME: OPTIMADE Developers
       GIT_USER_EMAIL: "dev@optimade.org"
 

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -30,7 +30,7 @@ jobs:
         git reset --hard ${{ env.DEPENDABOT_BRANCH }}
 
     - name: Fetch PR body
-      run: echo "PR_BODY=$(cat .github/utils/single_dependency_pr_body.txt)" >> $GITHUB_ENV
+      run: echo "PR_BODY=\"$(cat .github/utils/single_dependency_pr_body.txt)\"" >> $GITHUB_ENV
 
     - name: Create PR
       id: cpr

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -6,7 +6,6 @@ on:
     # Dependabot runs once a week (every Monday) (pip)
     # and every day (GH Actions) at 7:00 (5:00 UTC)
     - cron: "30 6 * * 3"
-  pull_request:
 
 jobs:
 
@@ -15,7 +14,7 @@ jobs:
     if: github.repository_owner == 'Materials-Consortia'
     runs-on: ubuntu-latest
     env:
-      DEPENDABOT_BRANCH: fix-167-single-dependabot-pr
+      DEPENDABOT_BRANCH: ci/dependabot-updates
       GIT_USER_NAME: OPTIMADE Developers
       GIT_USER_EMAIL: "dev@optimade.org"
 

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -31,9 +31,7 @@ jobs:
         git reset --hard ${{ env.DEPENDABOT_BRANCH }}
 
     - name: Fetch PR body
-      run: |
-        PR_BODY="$(cat .github/utils/single_dependency_pr_body.txt)"
-        echo "PR_BDOY=${PR_BODY}" >> $GITHUB_ENV
+      run: echo "PR_BDOY=$(cat .github/utils/single_dependency_pr_body.txt)" >> $GITHUB_ENV
 
     - name: Create PR
       id: cpr

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -33,12 +33,12 @@ jobs:
     - name: Fetch PR body
       id: pr_body
       run: |
-        PR_BDOY=$(cat .github/utils/single_dependency_pr_body.txt)
-        PR_BODY="${PR_BODY//'%'/'%25'}"
-        PR_BODY="${PR_BODY//$'\n'/'%0A'}"
-        PR_BODY="${PR_BODY//$'\r'/'%0D'}"
-        echo ::set-output name=PR_BODY::$PR_BODY
+        PR_BDOY='$(cat .github/utils/single_dependency_pr_body.txt)'
+        PR_BODY='${PR_BODY//"%"/"%25"}'
+        PR_BODY='${PR_BODY//$"\n"/"%0A"}'
+        PR_BODY='${PR_BODY//$"\r"/"%0D"}'
         echo $PR_BODY
+        echo ::set-output name=PR_BODY::$PR_BODY
 
     - name: Create PR
       id: cpr

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -6,6 +6,7 @@ on:
     # Dependabot runs once a week (every Monday) (pip)
     # and every day (GH Actions) at 7:00 (5:00 UTC)
     - cron: "30 6 * * 3"
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -32,13 +32,9 @@ jobs:
 
     - name: Fetch PR body
       id: pr_body
-      run: |
-        PR_BDOY='$(cat .github/utils/single_dependency_pr_body.txt)'
-        PR_BODY='${PR_BODY//"%"/"%25"}'
-        PR_BODY='${PR_BODY//$"\n"/"%0A"}'
-        PR_BODY='${PR_BODY//$"\r"/"%0D"}'
-        echo $PR_BODY
-        echo ::set-output name=PR_BODY::$PR_BODY
+      uses: chuhlomin/render-template@v1.2
+      with:
+        template: .github/utils/single_dependency_pr_body.txt
 
     - name: Create PR
       id: cpr
@@ -51,7 +47,7 @@ jobs:
         branch: ci/update-dependencies
         delete-branch: true
         title: Update dependencies
-        body: ${{ steps.pr_body.outputs.PR_BODY }}
+        body: ${{ steps.pr_body.outputs.result }}
         labels: CI/CD,dependencies
 
     - name: Information

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -31,13 +31,14 @@ jobs:
         git reset --hard ${{ env.DEPENDABOT_BRANCH }}
 
     - name: Fetch PR body
-      id: pr-body
+      id: pr_body
       run: |
         PR_BDOY=$(cat .github/utils/single_dependency_pr_body.txt)
         PR_BODY="${PR_BODY//'%'/'%25'}"
         PR_BODY="${PR_BODY//$'\n'/'%0A'}"
         PR_BODY="${PR_BODY//$'\r'/'%0D'}"
         echo ::set-output name=PR_BODY::$PR_BODY
+        echo $PR_BODY
 
     - name: Create PR
       id: cpr
@@ -50,7 +51,7 @@ jobs:
         branch: ci/update-dependencies
         delete-branch: true
         title: Update dependencies
-        body: "${{ steps.pr-body.outputs.PR_BODY }}"
+        body: ${{ steps.pr_body.outputs.PR_BODY }}
         labels: CI/CD,dependencies
 
     - name: Information

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -31,7 +31,9 @@ jobs:
         git reset --hard ${{ env.DEPENDABOT_BRANCH }}
 
     - name: Fetch PR body
-      run: echo "PR_BODY=\"$(cat .github/utils/single_dependency_pr_body.txt)\"" >> $GITHUB_ENV
+      run: |
+        PR_BODY="$(cat .github/utils/single_dependency_pr_body.txt)"
+        echo "PR_BDOY=${PR_BODY}" >> $GITHUB_ENV
 
     - name: Create PR
       id: cpr

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -31,7 +31,13 @@ jobs:
         git reset --hard ${{ env.DEPENDABOT_BRANCH }}
 
     - name: Fetch PR body
-      run: echo "PR_BDOY=$(cat .github/utils/single_dependency_pr_body.txt)" >> $GITHUB_ENV
+      id: pr-body
+      run: |
+        PR_BDOY=$(cat .github/utils/single_dependency_pr_body.txt)
+        PR_BODY="${PR_BODY//'%'/'%25'}"
+        PR_BODY="${PR_BODY//$'\n'/'%0A'}"
+        PR_BODY="${PR_BODY//$'\r'/'%0D'}"
+        echo ::set-output name=PR_BODY::$PR_BODY
 
     - name: Create PR
       id: cpr
@@ -44,7 +50,7 @@ jobs:
         branch: ci/update-dependencies
         delete-branch: true
         title: Update dependencies
-        body: "${{ env.PR_BODY }}"
+        body: "${{ steps.pr-body.outputs.PR_BODY }}"
         labels: CI/CD,dependencies
 
     - name: Information


### PR DESCRIPTION
Fixes #167 

Wrap bash variable definition in excepted double-quotation marks and convert any double-quotation marks in the `cat`'ed file to single-quotation marks.