### PR TITLE
Use `ref` instead of `sha`

### DIFF
--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v2


### PR DESCRIPTION
This is for checking out the branch in the CI automerge workflow.

Fixes #177.