### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -84,7 +84,7 @@ jobs:
 
     - name: Fetch PR body
       id: pr_body
-      uses: chuhlomin/render-template@v1.3
+      uses: chuhlomin/render-template@v1.4
       with:
         template: .github/utils/single_dependency_pr_body.txt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     exclude: ^tests/.*$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.930
+  rev: v0.931
   hooks:
   - id: mypy
     exclude: ^tests/.*$

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-httpx~=0.21.1
+httpx~=0.21.3
 motor~=2.5
 optimade[server]~=0.16.8


### PR DESCRIPTION
### Update dependencies

Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
It should be automagically merged into `main` upon CI success.

For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).