### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Create PR
       id: cpr
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         commit-message: New @dependabot-fueled updates

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     exclude: .*\.md$
 
 - repo: https://github.com/ambv/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     name: Blacken
@@ -20,7 +20,7 @@ repos:
     exclude: ^tests/.*$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.941
+  rev: v0.942
   hooks:
   - id: mypy
     exclude: ^tests/.*$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ disable = [
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-required_plugins = "pytest-asyncio>=0.18.2 pytest-cov>=3.0 pytest-httpx>=0.20.0"
+required_plugins = "pytest-asyncio>=0.18.3 pytest-cov>=3.0 pytest-httpx>=0.20.0"
 addopts = "-rs --cov=./optimade_gateway/ --cov-report=term --durations=10"
 filterwarnings = [
     "ignore:.*imp module.*:DeprecationWarning"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 httpx~=0.22.0
 motor~=2.5
-optimade[server]~=0.16.11
+optimade[server]~=0.16.12

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 pre-commit~=2.17
 pylint~=2.13
 pytest~=7.1
-pytest-asyncio~=0.18.2
+pytest-asyncio~=0.18.3
 pytest-cov~=3.0
 pytest-httpx~=0.20.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 pre-commit~=2.17
-pylint~=2.12
+pylint~=2.13
 pytest~=7.1
 pytest-asyncio~=0.18.2
 pytest-cov~=3.0

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,6 @@
 invoke~=1.7
 mike~=1.1
-mkdocs~=1.2
+mkdocs~=1.3
 mkdocs-awesome-pages-plugin~=2.7
 mkdocs-material~=8.2
 mkdocstrings~=0.18.1


### PR DESCRIPTION
### Update dependencies

Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
It should be automagically merged into `main` upon CI success.

For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).