### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -107,7 +107,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-gateway'
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         name: optimade-gateway
         files: ./coverage.xml

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pre-commit~=2.17
+pre-commit~=2.18
 pylint~=2.13
 pytest~=7.1
 pytest-asyncio~=0.18.3


### PR DESCRIPTION
### Update dependencies

Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
It should be automagically merged into `main` upon CI success.

For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).