### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -24,7 +24,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -83,7 +83,7 @@ jobs:
   #       fetch-depth: 2
 
   #   - name: Set up Python 3.8
-  #     uses: actions/setup-python@v3
+  #     uses: actions/setup-python@v4
   #     with:
   #       python-version: 3.8
 
@@ -115,7 +115,7 @@ jobs:
         ref: ${{ env.PUBLISH_UPDATE_BRANCH }}
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -30,7 +30,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Set up Python 3.8
       if: env.RELEASE_RUN == 'false'
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -25,7 +25,7 @@ jobs:
         ref: main
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -52,7 +52,7 @@ jobs:
         fetch-depth: 2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -90,7 +90,7 @@ jobs:
         fetch-depth: 2
 
     - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version}}
 
@@ -154,7 +154,7 @@ jobs:
       with:
         fetch-depth: 2
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -3,4 +3,4 @@ mike~=1.1
 mkdocs~=1.3
 mkdocs-awesome-pages-plugin~=2.7
 mkdocs-material~=8.3
-mkdocstrings[python]~=0.18.1
+mkdocstrings[python]~=0.19.0


### PR DESCRIPTION
### Update dependencies

Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
It should be automagically merged into `main` upon CI success.

For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).