### PR TITLE
Update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     exclude: ^tests/.*$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.1.1
+  rev: v1.2.0
   hooks:
   - id: mypy
     exclude: ^tests/.*$

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 pre-commit~=3.2
 pylint~=2.17
-pytest~=7.2
+pytest~=7.3
 pytest-asyncio~=0.21.0
 pytest-cov~=4.0
 pytest-httpx~=0.21.3

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -3,4 +3,4 @@ mike~=1.1
 mkdocs~=1.4
 mkdocs-awesome-pages-plugin~=2.8
 mkdocs-material~=9.1
-mkdocstrings[python]~=0.20.0
+mkdocstrings[python]~=0.21.2


### PR DESCRIPTION
### Update dependencies

Automatically created PR from [`ci/dependabot-updates`](https://github.com/Materials-Consortia/optimade-gateway/tree/ci/dependabot-updates).
It should be automagically merged into `main` upon CI success.

For more information see the ["Dependabot updates" workflow](https://github.com/Materials-Consortia/optimade-gateway/blob/main/.github/workflows/ci_dependabot.yml).