### PR TITLE
Use PAT instead of GITHUB_TOKEN for changelog steps

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Update changelog
       uses: CharMixer/auto-changelog-action@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.RELEASE_PAT_CASPER }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
 
     - name: Update documentation and version - Commit changes and update tag
@@ -58,7 +58,7 @@ jobs:
     - name: Create release-specific changelog
       uses: CharMixer/auto-changelog-action@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.RELEASE_PAT_CASPER }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"


### PR DESCRIPTION
Fixes #368 