### PR TITLE
Split dependency version ranges according to Py3.8 support

### DIFF
--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DEPENDABOT_BRANCH: ci/dependabot-updates
       GIT_USER_NAME: OPTIMADE Developers
       GIT_USER_EMAIL: "dev@optimade.org"
 
@@ -21,53 +20,6 @@ jobs:
       run: |
         git config --global user.name "${GIT_USER_NAME}"
         git config --global user.email "${GIT_USER_EMAIL}"
-
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
-        persist-credentials: false
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools wheel
-
-        while IFS="" read -r line || [ -n "${line}" ]; do
-          if [[ "${line}" =~ ^invoke.*$ ]]; then
-            invoke="${line}"
-          fi
-        done < requirements_docs.txt
-
-        pip install ${invoke}
-
-    - name: Run task, commit and push changes
-      run: |
-        invoke update-pytest-reqs
-
-        git add pyproject.toml
-        if [ -n "$(git status --porcelain pyproject.toml)" ]; then
-          # Only commit if there's something to commit (git will return non-zero otherwise)
-          echo "Committing update to pytest dependency config !"
-          git commit -m "Update pytest dependency config"
-          echo "PUSH_BACK_TO_BRANCH=true" >> $GITHUB_ENV
-        else
-          echo "No changes to pytest dependency config."
-          echo "PUSH_BACK_TO_BRANCH=false" >> $GITHUB_ENV
-        fi
-
-    - name: Update Dependabot branch
-      if: env.PUSH_BACK_TO_BRANCH == 'true'
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.RELEASE_PAT_CASPER }}
-        branch: ${{ github.event.pull_request.head.ref }}
 
     - name: Activate auto-merge
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,13 +62,3 @@ repos:
     types: [python]
     require_serial: true
     exclude: ^tests/.*$
-  - id: pytest-plugins
-    name: pytest required plugin versions
-    entry: invoke
-    args: [update-pytest-reqs]
-    language: python
-    always_run: true
-    types: [text]
-    pass_filenames: false
-    files: ^requirements_dev.txt$
-    description: Update the pytest plugins to be minimum the currently listed requirement versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ disable = [
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-required_plugins = "pytest-asyncio>=0.21.0 pytest-cov>=4.1 pytest-httpx>=0.22.0"
+required_plugins = "pytest-asyncio pytest-cov pytest-httpx"
 addopts = "-rs --cov=./optimade_gateway/ --cov-report=term --durations=10"
 filterwarnings = [
     "ignore:.*imp module.*:DeprecationWarning"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 httpx~=0.24.1
 motor~=3.1
-optimade[server]~=0.24.1
+optimade[server]~=0.24.1; python_version < "3.9"
+optimade[server]~=0.25.1; python_version >= "3.9"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,4 +3,5 @@ pylint~=2.17
 pytest~=7.3
 pytest-asyncio~=0.21.0
 pytest-cov~=4.1
-pytest-httpx~=0.22.0
+pytest-httpx~=0.22.0; python_version < "3.9"
+pytest-httpx~=0.23.1; python_version >= "3.9"

--- a/tasks.py
+++ b/tasks.py
@@ -13,8 +13,6 @@ from invoke import task
 if TYPE_CHECKING:
     from typing import Optional, Tuple
 
-    from invoke import Context, Result
-
 
 TOP_DIR = Path(__file__).parent.resolve()
 
@@ -66,78 +64,3 @@ def setver(_, ver=""):
     )
 
     print(f"Bumped version to {ver}")
-
-
-@task
-def update_pytest_reqs(_):
-    """Update the pytest plugins to be minimum the currently listed requirement
-    versions."""
-    from copy import deepcopy
-
-    config = TOP_DIR / "pyproject.toml"
-    requirements = TOP_DIR / "requirements_dev.txt"
-
-    # Retrieve dependencies specified in the config file
-    with open(config, encoding="utf8") as handle:
-        for line in handle.readlines():
-            plugins = re.match(r'^required_plugins = "(?P<plugins>.*)".*', line)
-            if plugins:
-                break
-        else:
-            raise RuntimeError(
-                "Couldn't find the required plugins for pytest in the config file at "
-                f"{config} !"
-            )
-
-    plugins = {
-        dependency.group("name"): dependency.group("version")
-        for dependency in [
-            re.match(r"^(?P<name>[a-z-]+)>=(?P<version>[0-9]+(\.[0-9]+){1,2})$", _)
-            for _ in plugins.group("plugins").split(" ")  # type: ignore[union-attr]
-        ]
-        if dependency
-    }
-    original_versions = deepcopy(plugins)
-
-    # Update the retrieved versions with those from the requirements file
-    dependencies_found_counter = 0
-    with open(requirements, encoding="utf8") as handle:
-        for line in handle.readlines():
-            for plugin in plugins:
-                dependency = re.match(
-                    rf"^{plugin}~=(?P<version>[0-9]+(\.[0-9]+){{1,2}}).*", line
-                )
-                if not dependency:
-                    continue
-                dependencies_found_counter += 1
-                plugins[plugin] = dependency.group("version")
-
-    # Sanity check
-    if dependencies_found_counter != len(plugins):
-        raise RuntimeError(
-            f"Did not find all specified dependencies from the config file ({config}) in "
-            f"the development requirements file ({requirements}).\nDependencies found in "
-            f"the requirements file: {dependencies_found_counter}\nDependencies found in "
-            f"the config file: {len(plugins)}"
-        )
-
-    # Update the config file dependency versions (if necessary)
-    for plugin in original_versions:
-        if original_versions[plugin] != plugins[plugin]:
-            break
-    else:
-        print("No updates detected; the config file is up-to-date.")
-        sys.exit()
-
-    update_file(
-        config,
-        (
-            r"^required_plugins = .*",
-            'required_plugins = "'
-            f'{" ".join(f"{name}>={version}" for name, version in plugins.items())}"',
-        ),
-    )
-    print(
-        f"Successfully updated pytest config plugins:\n        {plugins}\n  (was: "
-        f"{original_versions})"
-    )


### PR DESCRIPTION
Closes #387 

Also, this PR removes the version constraints for pytest add-ons, removing an invoke task as well as some steps in the auto-merge CI workflow for dependabot PRs.