### PR TITLE
Migrate to pydantic v2

### DIFF
--- a/.ci/test_databases.json
+++ b/.ci/test_databases.json
@@ -35,7 +35,7 @@
     "name": "Materials Cloud",
     "description": "A platform for Open Science built for seamless sharing of resources in computational materials science",
     "base_url": "https://dev-www.materialscloud.org/optimade",
-    "homepage": "https://dev-www.materialscloud.org",
+    "homepage": "https://dev-www.materialscloud.org/",
     "link_type": "external"
   },
   {
@@ -43,7 +43,7 @@
     "type": "links",
     "name": "OPTIMADE Python tools",
     "description": "The example implementation from the OPTIMADE Python tools. This gateway and database is used for the docker job in the CI workflow.",
-    "base_url": "http://optimade-sample-server:5000",
+    "base_url": "http://optimade-sample-server:5000/",
     "homepage": "https://github.com/Materials-Consortia/optimade-python-tools",
     "link_type": "child",
     "aggregate": "ok"
@@ -53,7 +53,7 @@
     "type": "links",
     "name": "Sleepy database",
     "description": "Not an OPTIMADE database, just a placeholder for instantiating a callback that sleeps before returning a mocked `optimade-sample` DB response.",
-    "base_url": "https://sleep-1",
+    "base_url": "https://sleep-1/",
     "homepage": "https://github.com/Materials-Consortia/optimade-gateway",
     "link_type": "child",
     "aggregate": "test"

--- a/.ci/test_gateways.json
+++ b/.ci/test_gateways.json
@@ -46,7 +46,7 @@
           "name": "Materials Cloud",
           "description": "A platform for Open Science built for seamless sharing of resources in computational materials science",
           "base_url": "https://dev-www.materialscloud.org/optimade",
-          "homepage": "https://dev-www.materialscloud.org",
+          "homepage": "https://dev-www.materialscloud.org/",
           "link_type": "external"
         }
       }
@@ -152,7 +152,7 @@
         "attributes": {
           "name": "OPTIMADE Python tools",
           "description": "The example implementation from the OPTIMADE Python tools. This gateway and database is used for the docker job in the CI workflow.",
-          "base_url": "http://optimade-sample-server:5000",
+          "base_url": "http://optimade-sample-server:5000/",
           "homepage": "https://github.com/Materials-Consortia/optimade-python-tools",
           "link_type": "child",
           "aggregate": "ok"
@@ -183,7 +183,7 @@
           "name": "Materials Cloud",
           "description": "A platform for Open Science built for seamless sharing of resources in computational materials science",
           "base_url": "https://dev-www.materialscloud.org/optimade",
-          "homepage": "https://dev-www.materialscloud.org",
+          "homepage": "https://dev-www.materialscloud.org/",
           "link_type": "external"
         }
       }
@@ -199,7 +199,7 @@
         "attributes": {
           "name": "Sleepy database",
           "description": "Not an OPTIMADE database, just a placeholder for instantiating a callback that sleeps before returning a mocked `optimade-sample` DB response.",
-          "base_url": "https://sleep-1",
+          "base_url": "https://sleep-1/",
           "homepage": "https://github.com/Materials-Consortia/optimade-gateway",
           "link_type": "child",
           "aggregate": "test"
@@ -241,7 +241,7 @@
         "attributes": {
           "name": "Random database",
           "description": "A random database not used anywhere else.",
-          "base_url": "http://random-database",
+          "base_url": "http://random-database/",
           "homepage": null,
           "link_type": "child"
         }

--- a/.ci/test_links.json
+++ b/.ci/test_links.json
@@ -4,8 +4,8 @@
     "type": "links",
     "name": "Index meta-database",
     "description": "Index for the OPTIMADE Gateway",
-    "base_url": "https://index.example.org",
-    "homepage": "https://example.org",
+    "base_url": "https://index.example.org/",
+    "homepage": "https://example.org/",
     "link_type": "root"
   },
   {
@@ -13,8 +13,8 @@
     "type": "links",
     "name": "Materials-Consortia's list of providers",
     "description": "List of OPTIMADE API providers by Materials-Consortia, pointing to materials database providers.",
-    "base_url": "https://providers.optimade.org",
-    "homepage": "https://www.optimade.org",
+    "base_url": "https://providers.optimade.org/",
+    "homepage": "https://www.optimade.org/",
     "link_type": "providers"
   }
 ]

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-repo-and-release:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.3
     if: github.repository == 'Materials-Consortia/optimade-gateway' && startsWith(github.ref, 'refs/tags/v')
     with:
       # General

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -19,7 +19,7 @@ jobs:
 
       # PyPI publishing
       python_package: true
-      python_version_build: "3.9"
+      python_version_build: "3.10"
       package_dirs: "optimade_gateway"
       version_update_changes_separator: ";"
       version_update_changes: |
@@ -32,7 +32,7 @@ jobs:
 
       # Documentation
       update_docs: true
-      python_version_docs: "3.9"
+      python_version_docs: "3.10"
       doc_extras: "[docs]"
       docs_framework: "mkdocs"
     secrets:

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -19,7 +19,7 @@ jobs:
 
       # PyPI publishing
       python_package: true
-      python_version_build: "3.8"
+      python_version_build: "3.9"
       package_dirs: "optimade_gateway"
       version_update_changes_separator: ";"
       version_update_changes: |
@@ -32,7 +32,7 @@ jobs:
 
       # Documentation
       update_docs: true
-      python_version_docs: "3.8"
+      python_version_docs: "3.9"
       doc_extras: "[docs]"
       docs_framework: "mkdocs"
     secrets:

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-repo-and-release:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.3
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.6.0
     if: github.repository == 'Materials-Consortia/optimade-gateway' && startsWith(github.ref, 'refs/tags/v')
     with:
       # General

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependabot-branch:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.5.3
     if: github.repository_owner == 'Materials-Consortia' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'CasperWA' ) )
     secrets:
       PAT: ${{ secrets.RELEASE_PAT_CASPER }}

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependabot-branch:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.5.3
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.6.0
     if: github.repository_owner == 'Materials-Consortia' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'CasperWA' ) )
     secrets:
       PAT: ${{ secrets.RELEASE_PAT_CASPER }}

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependabot-branch-and-docs:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.5.3
     if: github.repository_owner == 'Materials-Consortia'
     with:
       # General

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -23,7 +23,7 @@ jobs:
       update_python_api_ref: true
       package_dirs: optimade_gateway
       update_docs_landing_page: true
-      python_version: "3.8"
+      python_version: "3.9"
       doc_extras: "[docs]"
       exclude_files: |
         __init__.py

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependabot-branch-and-docs:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.5.3
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.6.0
     if: github.repository_owner == 'Materials-Consortia'
     with:
       # General

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -23,7 +23,7 @@ jobs:
       update_python_api_ref: true
       package_dirs: optimade_gateway
       update_docs_landing_page: true
-      python_version: "3.9"
+      python_version: "3.10"
       doc_extras: "[docs]"
       exclude_files: |
         __init__.py

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-dependencies:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.3
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.6.0
     if: github.repository_owner == 'Materials-Consortia'
     with:
       git_username: OPTIMADE Developers

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-dependencies:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.3
     if: github.repository_owner == 'Materials-Consortia'
     with:
       git_username: OPTIMADE Developers

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -14,7 +14,7 @@ jobs:
       git_username: OPTIMADE Developers
       git_email: "dev@optimade.org"
       permanent_dependencies_branch: ci/dependabot-updates
-      python_version: "3.9"
+      python_version: "3.10"
       install_extras: "[dev]"
       pr_labels: "dependencies"
       ignore: |

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -14,7 +14,7 @@ jobs:
       git_username: OPTIMADE Developers
       git_email: "dev@optimade.org"
       permanent_dependencies_branch: ci/dependabot-updates
-      python_version: "3.8"
+      python_version: "3.9"
       install_extras: "[dev]"
       pr_labels: "dependencies"
       ignore: |

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-collected-pr:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.5.3
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.6.0
     if: github.repository_owner == 'Materials-Consortia'
     with:
       # General

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-collected-pr:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.5.3
     if: github.repository_owner == 'Materials-Consortia'
     with:
       # General

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -25,7 +25,7 @@ jobs:
 
       # Pre-commit
       update_pre-commit: true
-      python_version: "3.8"
+      python_version: "3.9"
       install_extras: "[dev]"
     secrets:
       PAT: ${{ secrets.RELEASE_PAT_CASPER }}

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -25,7 +25,7 @@ jobs:
 
       # Pre-commit
       update_pre-commit: true
-      python_version: "3.9"
+      python_version: "3.10"
       install_extras: "[dev]"
     secrets:
       PAT: ${{ secrets.RELEASE_PAT_CASPER }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   basic_tests:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.5.3
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.6.0
     with:
       # General
       install_extras: "[dev]"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -62,10 +62,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10"]
+        database-backend: ["mongodb", "mongomock"]
 
     services:
       mongo:
-        image: mongo:5
+        image: mongo:7
         ports:
         - 27017:27017
 
@@ -88,6 +89,7 @@ jobs:
     - name: Test with pytest
       env:
         OPTIMADE_MONGO_URI: "mongodb://localhost:27017"
+        OPTIMADE_DATABASE_BACKEND: ${{ matrix.database-backend }}
       run: pytest -vvv --cov-report=xml
 
     - name: Upload coverage to Codecov
@@ -97,7 +99,6 @@ jobs:
         name: optimade-gateway
         files: ./coverage.xml
         flags: pytest
-
 
   docker:
     name: Docker

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -17,23 +17,23 @@ jobs:
 
       # pre-commit
       run_pre-commit: true
-      python_version_pre-commit: "3.8"
+      python_version_pre-commit: "3.9"
 
       # pylint & safety
-      python_version_pylint_safety: "3.8"
+      python_version_pylint_safety: "3.9"
 
       run_pylint: false
       run_safety: true
 
       # Build package
       run_build_package: true
-      python_version_package: "3.8"
+      python_version_package: "3.9"
       build_libs: "flit"
       build_cmd: "flit build"
 
       # Build documentation
       run_build_docs: true
-      python_version_docs: "3.8"
+      python_version_docs: "3.9"
       warnings_as_errors: true
 
       use_mkdocs: true
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     services:
       mongo:
@@ -91,7 +91,7 @@ jobs:
       run: pytest -vvv --cov-report=xml
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.8' && github.repository == 'Materials-Consortia/optimade-gateway'
+      if: matrix.python-version == '3.9' && github.repository == 'Materials-Consortia/optimade-gateway'
       uses: codecov/codecov-action@v3
       with:
         name: optimade-gateway

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -17,23 +17,23 @@ jobs:
 
       # pre-commit
       run_pre-commit: true
-      python_version_pre-commit: "3.9"
+      python_version_pre-commit: "3.10"
 
       # pylint & safety
-      python_version_pylint_safety: "3.9"
+      python_version_pylint_safety: "3.10"
 
       run_pylint: false
       run_safety: true
 
       # Build package
       run_build_package: true
-      python_version_package: "3.9"
+      python_version_package: "3.10"
       build_libs: "flit"
       build_cmd: "flit build"
 
       # Build documentation
       run_build_docs: true
-      python_version_docs: "3.9"
+      python_version_docs: "3.10"
       warnings_as_errors: true
 
       use_mkdocs: true
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
         database-backend: ["mongodb", "mongomock"]
 
     services:
@@ -71,9 +71,8 @@ jobs:
         - 27017:27017
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
+    - name: Checout repository
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version}}
       uses: actions/setup-python@v5
@@ -93,12 +92,16 @@ jobs:
       run: pytest -vvv --cov-report=xml
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.9' && github.repository == 'Materials-Consortia/optimade-gateway'
+      if: github.repository == 'Materials-Consortia/optimade-gateway'
       uses: codecov/codecov-action@v3
       with:
         name: optimade-gateway
         files: ./coverage.xml
-        flags: pytest
+        env_vars: OS,PYTHON
+        flags: ${{ matrix.database-backend }}
+      env:
+        OS: ubuntu-latest
+        PYTHON: ${{ matrix.python-version }}
 
   docker:
     name: Docker
@@ -106,9 +109,8 @@ jobs:
     # timeout-minutes
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
+    - name: Checout repository
+      uses: actions/checkout@v4
 
     - name: Build the Docker app
       run: docker-compose build

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   basic_tests:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.5.3
     with:
       # General
       install_extras: "[dev]"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.5
+  rev: v0.1.6
   hooks:
     - id: ruff
       args:
@@ -41,7 +41,7 @@ repos:
       - "pydantic<2"
 
 - repo: https://github.com/SINTEF/ci-cd
-  rev: v2.5.3
+  rev: v2.6.0
   hooks:
   - id: docs-api-reference
     args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,12 @@ repos:
   - id: trailing-whitespace
     args: [--markdown-linebreak-ext=md]
 
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.15.0
+  hooks:
+  - id: pyupgrade
+    args: [--py39-plus]
+
 - repo: https://github.com/ambv/black
   rev: 23.11.0
   hooks:
@@ -20,10 +26,12 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.1.6
   hooks:
-    - id: ruff
-      args:
-        - --fix
-        - --exit-non-zero-on-fix
+  - id: ruff
+    args:
+      - --fix
+      - --no-unsafe-fixes
+      - --show-fixes
+      - --exit-non-zero-on-fix
 
 - repo: https://github.com/PyCQA/bandit
   rev: '1.7.5'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,12 @@ repos:
     args: [--markdown-linebreak-ext=md]
 
 - repo: https://github.com/ambv/black
-  rev: 23.10.1
+  rev: 23.11.0
   hooks:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.3
+  rev: v0.1.4
   hooks:
     - id: ruff
       args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.2
+  rev: v0.1.3
   hooks:
     - id: ruff
       args:
@@ -41,7 +41,7 @@ repos:
       - "pydantic<2"
 
 - repo: https://github.com/SINTEF/ci-cd
-  rev: v2.5.2
+  rev: v2.5.3
   hooks:
   - id: docs-api-reference
     args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
   - id: mypy
     exclude: ^tests/.*$
     additional_dependencies:
-      - "pydantic<2"
+      - "pydantic>=2"
 
 - repo: https://github.com/SINTEF/ci-cd
   rev: v2.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.4
+  rev: v0.1.5
   hooks:
     - id: ruff
       args:
@@ -33,7 +33,7 @@ repos:
     exclude: ^tests/.*$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.6.1
+  rev: v1.7.0
   hooks:
   - id: mypy
     exclude: ^tests/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  python: python3.10
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
@@ -16,7 +19,7 @@ repos:
   rev: v3.15.0
   hooks:
   - id: pyupgrade
-    args: [--py39-plus]
+    args: [--py310-plus]
 
 - repo: https://github.com/ambv/black
   rev: 23.12.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.10-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/optimade_gateway/__init__.py
+++ b/optimade_gateway/__init__.py
@@ -4,6 +4,7 @@ OPTIMADE Gateway
 This package is a gateway server for querying databases exposing an OPTIMADE API.
 It is built using FastAPI and run using uvicorn.
 """
+from __future__ import annotations
 
 __version__ = "0.4.0"
 __author__ = "Casper Welzel Andersen"

--- a/optimade_gateway/common/config.py
+++ b/optimade_gateway/common/config.py
@@ -1,4 +1,6 @@
 """Configuration of the FastAPI server."""
+from __future__ import annotations
+
 import os
 import re
 from warnings import warn

--- a/optimade_gateway/common/config.py
+++ b/optimade_gateway/common/config.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 import os
 import re
+from typing import Annotated
 from warnings import warn
 
 from optimade.server.config import ServerConfig as OptimadeServerConfig
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
@@ -17,28 +18,40 @@ class ServerConfig(OptimadeServerConfig):
 
     """
 
-    databases_collection: str = Field(
-        "databases",
-        description="Mongo collection name for `/databases` endpoint resources.",
-    )
-    gateways_collection: str = Field(
-        "gateways",
-        description="Mongo collection name for `/gateways` endpoint resources.",
-    )
-    queries_collection: str = Field(
-        "queries",
-        description="Mongo collection name for `/queries` endpoint resources.",
-    )
-    load_optimade_providers_databases: bool = Field(
-        True,
-        description=(
-            "Whether or not to load all valid OPTIMADE providers' databases from the "
-            "[Materials-Consortia list of OPTIMADE providers]"
-            "(https://providers.optimade.org) on server startup."
+    databases_collection: Annotated[
+        str,
+        Field(
+            description="Mongo collection name for `/databases` endpoint resources.",
         ),
-    )
+    ] = "databases"
 
-    @validator("mongo_uri")
+    gateways_collection: Annotated[
+        str,
+        Field(
+            description="Mongo collection name for `/gateways` endpoint resources.",
+        ),
+    ] = "gateways"
+
+    queries_collection: Annotated[
+        str,
+        Field(
+            description="Mongo collection name for `/queries` endpoint resources.",
+        ),
+    ] = "queries"
+
+    load_optimade_providers_databases: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether or not to load all valid OPTIMADE providers' databases from "
+                "the [Materials-Consortia list of OPTIMADE providers]"
+                "(https://providers.optimade.org) on server startup."
+            ),
+        ),
+    ] = True
+
+    @field_validator("mongo_uri", mode="after")
+    @classmethod
     def replace_with_env_vars(cls, value: str) -> str:
         """Replace string variables with environment variables, if possible"""
         res = value

--- a/optimade_gateway/common/exceptions.py
+++ b/optimade_gateway/common/exceptions.py
@@ -1,4 +1,6 @@
 """Specific OPTIMADE Gateway Python exceptions."""
+from __future__ import annotations
+
 __all__ = ("OptimadeGatewayError",)
 
 

--- a/optimade_gateway/common/logger.py
+++ b/optimade_gateway/common/logger.py
@@ -1,4 +1,6 @@
 """Logging to both file and console"""
+from __future__ import annotations
+
 import logging
 import os
 import sys

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -2,6 +2,8 @@
 
 These functions may be used in general throughout the OPTIMADE Gateway Python code.
 """
+from __future__ import annotations
+
 from enum import Enum
 from os import getenv
 from typing import TYPE_CHECKING
@@ -9,17 +11,17 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    from typing import Any, Dict, Union
+    from typing import Any
 
 
-async def clean_python_types(data: "Any") -> "Any":
+async def clean_python_types(data: Any) -> Any:
     """Turn any types into MongoDB-friendly Python types.
 
     Use `dict()` method for Pydantic models.
     Use `value` property for Enums.
     Turn tuples and sets into lists.
     """
-    res: "Any" = None
+    res: Any = None
     if isinstance(data, (list, tuple, set)):
         res = []
         for datum in data:
@@ -42,11 +44,11 @@ async def clean_python_types(data: "Any") -> "Any":
 
 
 def get_resource_attribute(
-    resource: "Union[BaseModel, Dict[str, Any], None]",
+    resource: BaseModel | dict[str, Any] | None,
     field: str,
-    default: "Any" = None,
+    default: Any = None,
     disambiguate: bool = True,
-) -> "Any":
+) -> Any:
     """Return a resource's field's value
 
     Get the field value no matter if the resource is a pydantic model or a Python
@@ -78,7 +80,7 @@ def get_resource_attribute(
         _get_attr = getattr
     elif isinstance(resource, dict):
 
-        def _get_attr(mapping: dict, key: str, default: "Any") -> "Any":  # type: ignore[misc]
+        def _get_attr(mapping: dict, key: str, default: Any) -> Any:  # type: ignore[misc]
             return mapping.get(key, default)
 
     elif resource is None:
@@ -96,9 +98,11 @@ def get_resource_attribute(
     field = fields[-1]
     value = _get_attr(resource, field, default)
 
-    if disambiguate:
-        if field in ("base_url", "next", "prev", "last", "first"):
-            if not isinstance(value, str):
-                value = _get_attr(value, "href", default)
+    if (
+        disambiguate
+        and field in ("base_url", "next", "prev", "last", "first")
+        and not isinstance(value, str)
+    ):
+        value = _get_attr(value, "href", default)
 
     return value

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -32,7 +32,7 @@ async def clean_python_types(data: Any) -> Any:
             res[key] = await clean_python_types(data[key])
     elif isinstance(data, BaseModel):
         # Pydantic model
-        res = await clean_python_types(data.dict())
+        res = await clean_python_types(data.model_dump())
     elif isinstance(data, Enum):
         res = await clean_python_types(data.value)
     elif isinstance(data, type):

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -8,7 +8,7 @@ from enum import Enum
 from os import getenv
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
+from pydantic import AnyUrl, BaseModel
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from typing import Any
@@ -101,7 +101,7 @@ def get_resource_attribute(
     if (
         disambiguate
         and field in ("base_url", "next", "prev", "last", "first")
-        and not isinstance(value, str)
+        and not isinstance(value, (str, AnyUrl))
     ):
         value = _get_attr(value, "href", default)
 

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -22,16 +22,16 @@ async def clean_python_types(data: Any, **dump_kwargs: Any) -> Any:
     Turn tuples and sets into lists.
     """
     if isinstance(data, (list, tuple, set)):
-        res = []
+        res_list = []
         for datum in data:
-            res.append(await clean_python_types(datum, **dump_kwargs))
-        return res
+            res_list.append(await clean_python_types(datum, **dump_kwargs))
+        return res_list
 
     if isinstance(data, dict):
-        res = {}
+        res_dict = {}
         for key in list(data.keys()):
-            res[key] = await clean_python_types(data[key], **dump_kwargs)
-        return res
+            res_dict[key] = await clean_python_types(data[key], **dump_kwargs)
+        return res_dict
 
     if isinstance(data, BaseModel):
         # Pydantic model

--- a/optimade_gateway/common/utils.py
+++ b/optimade_gateway/common/utils.py
@@ -26,22 +26,24 @@ async def clean_python_types(data: Any, **dump_kwargs: Any) -> Any:
         for datum in data:
             res.append(await clean_python_types(datum, **dump_kwargs))
         return res
-    
+
     if isinstance(data, dict):
         res = {}
         for key in list(data.keys()):
             res[key] = await clean_python_types(data[key], **dump_kwargs)
         return res
-    
+
     if isinstance(data, BaseModel):
         # Pydantic model
         return await clean_python_types(data.model_dump(**dump_kwargs))
-    
+
     if isinstance(data, Enum):
         return await clean_python_types(data.value, **dump_kwargs)
 
     if isinstance(data, type):
-        return await clean_python_types(f"{data.__module__}.{data.__name__}", **dump_kwargs)
+        return await clean_python_types(
+            f"{data.__module__}.{data.__name__}", **dump_kwargs
+        )
 
     if isinstance(data, AnyUrl):
         return await clean_python_types(str(data), **dump_kwargs)

--- a/optimade_gateway/events.py
+++ b/optimade_gateway/events.py
@@ -4,6 +4,8 @@ These events can be run at application startup or shutdown.
 The specific events are listed in [`EVENTS`][optimade_gateway.events.EVENTS] along with
 their respected proper invocation time.
 """
+from __future__ import annotations
+
 import os
 from typing import TYPE_CHECKING
 
@@ -12,7 +14,7 @@ from optimade_gateway.common.logger import LOGGER
 
 if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from collections.abc import Callable, Coroutine, Sequence
-    from typing import Any, Tuple, Union
+    from typing import Any
 
 
 async def ci_dev_startup() -> None:
@@ -55,8 +57,8 @@ async def ci_dev_startup() -> None:
             f"Could not find test data file with test gateways at {test_data} !"
         )
 
-    with open(test_data, encoding="utf8") as handle:
-        data = json.load(handle)
+    data = json.loads(test_data.read_bytes())
+
     await MONGO_DB[CONFIG.gateways_collection].insert_many(data)
 
 
@@ -87,7 +89,7 @@ async def load_optimade_providers_databases() -> None:
         return
 
     if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-        providers: "Union[httpx.Response, LinksResponse]"
+        providers: httpx.Response | LinksResponse
 
     async with httpx.AsyncClient() as client:
         providers = await client.get(
@@ -231,7 +233,7 @@ async def load_optimade_providers_databases() -> None:
             )
 
 
-EVENTS: "Sequence[Tuple[str, Callable[[], Coroutine[Any, Any, None]]]]" = (
+EVENTS: Sequence[tuple[str, Callable[[], Coroutine[Any, Any, None]]]] = (
     ("startup", ci_dev_startup),
     ("startup", load_optimade_providers_databases),
 )

--- a/optimade_gateway/events.py
+++ b/optimade_gateway/events.py
@@ -11,13 +11,7 @@ from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 
 if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Callable, Coroutine, Sequence
-    else:
-        from typing import Callable, Coroutine, Sequence
-
+    from collections.abc import Callable, Coroutine, Sequence
     from typing import Any, Tuple, Union
 
 

--- a/optimade_gateway/exception_handlers.py
+++ b/optimade_gateway/exception_handlers.py
@@ -4,6 +4,8 @@ These are in addition to the exception handlers available in OPTIMADE Python too
 For more information see
 https://www.optimade.org/optimade-python-tools/api_reference/server/exception_handlers/.
 """
+from __future__ import annotations
+
 from os import getenv
 from typing import TYPE_CHECKING
 
@@ -17,8 +19,8 @@ if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
 
 
 async def request_validation_exception_handler(
-    request: "Request", exc: "RequestValidationError"
-) -> "JSONResponse":
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
     """Special handler if a `RequestValidationError` comes from wrong `POST` data"""
     status_code = 500
     if request.method in ("POST", "post"):

--- a/optimade_gateway/main.py
+++ b/optimade_gateway/main.py
@@ -1,4 +1,6 @@
 """The initialization of the ASGI FastAPI application."""
+from __future__ import annotations
+
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import RedirectResponse
@@ -43,14 +45,16 @@ for middleware in OPTIMADE_MIDDLEWARE:
 # Add exception handlers
 for exception, handler in OPTIMADE_EXCEPTIONS:
     if exception == RequestValidationError:
-        handler = request_validation_exception_handler
-    APP.add_exception_handler(exception, handler)
+        APP.add_exception_handler(exception, request_validation_exception_handler)
+    else:
+        APP.add_exception_handler(exception, handler)
+
 
 # Add the special /versions endpoint(s)
 APP.include_router(versions_router)
 
 # Add endpoints to / and /vMAJOR
-for prefix in list(BASE_URL_PREFIXES.values()) + [""]:
+for prefix in [*list(BASE_URL_PREFIXES.values()), ""]:
     for router in (databases, gateways, info, links, queries, search):
         APP.include_router(
             router.ROUTER,  # type: ignore[attr-defined]

--- a/optimade_gateway/mappers/__init__.py
+++ b/optimade_gateway/mappers/__init__.py
@@ -2,6 +2,8 @@
 
 The design for these mappers is based on the mappers in OPTIMADE Python tools.
 """
+from __future__ import annotations
+
 from .databases import DatabasesMapper
 from .gateways import GatewaysMapper
 from .links import LinksMapper

--- a/optimade_gateway/mappers/base.py
+++ b/optimade_gateway/mappers/base.py
@@ -15,13 +15,7 @@ from pydantic import AnyUrl
 from optimade_gateway.common.config import CONFIG
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Iterable
-    else:
-        from typing import Iterable
-
+    from collections.abc import Iterable
     from typing import List, Union
 
     from optimade.models import EntryResource

--- a/optimade_gateway/mappers/base.py
+++ b/optimade_gateway/mappers/base.py
@@ -86,8 +86,6 @@ class BaseResourceMapper(OptimadeBaseResourceMapper):
                     f"{CONFIG.base_url.strip('/')}{BASE_URL_PREFIXES['major']}"
                     f"/{cls.ENDPOINT}/{doc['id']}"
                 ),
-                scheme=CONFIG.base_url.split("://", maxsplit=1)[0],
-                host=CONFIG.base_url.split("://", maxsplit=2)[1].split("/")[0],
             )
         }
         return super().map_back(doc)

--- a/optimade_gateway/mappers/base.py
+++ b/optimade_gateway/mappers/base.py
@@ -4,6 +4,8 @@ Based on the
 [`BaseResourceMapper`](https://www.optimade.org/optimade-python-tools/api_reference/server/mappers/entries/#optimade.server.mappers.entries.BaseResourceMapper)
 in OPTIMADE Python tools.
 """
+from __future__ import annotations
+
 from os import getenv
 from typing import TYPE_CHECKING
 
@@ -16,7 +18,6 @@ from optimade_gateway.common.config import CONFIG
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from collections.abc import Iterable
-    from typing import List, Union
 
     from optimade.models import EntryResource
 
@@ -55,8 +56,8 @@ class BaseResourceMapper(OptimadeBaseResourceMapper):
 
     @classmethod
     async def adeserialize(
-        cls, results: "Union[dict, Iterable[dict]]"
-    ) -> "Union[List[EntryResource], EntryResource]":
+        cls, results: dict | Iterable[dict]
+    ) -> list[EntryResource] | EntryResource:
         """Asynchronous version of the `deserialize()` class method.
 
         Parameters:
@@ -68,7 +69,7 @@ class BaseResourceMapper(OptimadeBaseResourceMapper):
             `results`.
 
         """
-        return super(BaseResourceMapper, cls).deserialize(results)
+        return super().deserialize(results)
 
     @classmethod
     def map_back(cls, doc: dict) -> dict:

--- a/optimade_gateway/mappers/databases.py
+++ b/optimade_gateway/mappers/databases.py
@@ -2,6 +2,8 @@
 
 These resources are [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource)s.
 """
+from __future__ import annotations
+
 from optimade_gateway.mappers.links import LinksMapper
 
 

--- a/optimade_gateway/mappers/gateways.py
+++ b/optimade_gateway/mappers/gateways.py
@@ -1,5 +1,7 @@
 """Resource mapper for
 [`GatewayResource`][optimade_gateway.models.gateways.GatewayResource]."""
+from __future__ import annotations
+
 from optimade_gateway.mappers.base import BaseResourceMapper
 from optimade_gateway.models import GatewayResource
 

--- a/optimade_gateway/mappers/links.py
+++ b/optimade_gateway/mappers/links.py
@@ -1,6 +1,8 @@
 """Replicate of
 [`LinksMapper`](https://www.optimade.org/optimade-python-tools/api_reference/server/mappers/links/#optimade.server.mappers.links.LinksMapper)
 in OPTIMADE Python tools."""
+from __future__ import annotations
+
 from optimade.models.links import LinksResource
 
 from optimade_gateway.mappers.base import BaseResourceMapper

--- a/optimade_gateway/mappers/queries.py
+++ b/optimade_gateway/mappers/queries.py
@@ -1,5 +1,7 @@
 """Resource mapper for
 [`QueryResource`][optimade_gateway.models.queries.QueryResource]."""
+from __future__ import annotations
+
 from optimade_gateway.mappers.base import BaseResourceMapper
 from optimade_gateway.models import QueryResource
 

--- a/optimade_gateway/middleware.py
+++ b/optimade_gateway/middleware.py
@@ -4,6 +4,8 @@ These are in addition to the middleware available in OPTIMADE Python tools.
 For more information see
 https://www.optimade.org/optimade-python-tools/api_reference/server/middleware/.
 """
+from __future__ import annotations
+
 import re
 from os import getenv
 from typing import TYPE_CHECKING
@@ -22,7 +24,7 @@ class CheckWronglyVersionedBaseUrlsGateways(BaseHTTPMiddleware):
     return `553 Version Not Supported`."""
 
     @staticmethod
-    async def check_url(url: "URL"):
+    async def check_url(url: URL):
         """Check URL path for versioned part.
 
         Parameters:
@@ -38,19 +40,20 @@ class CheckWronglyVersionedBaseUrlsGateways(BaseHTTPMiddleware):
         match = re.match(
             r"^/gateways/[^/\s]+(?P<version>/v[0-9]+(\.[0-9]+){0,2}).*", optimade_path
         )
-        if match is not None:
-            if match.group("version") not in BASE_URL_PREFIXES.values():
-                raise VersionNotSupported(
-                    detail=(
-                        f"The parsed versioned base URL {match.group('version')!r} "
-                        f"from {url} is not supported by this implementation. "
-                        "Supported versioned base URLs are: "
-                        f"{', '.join(BASE_URL_PREFIXES.values())}"
-                    )
+        if (
+            match is not None
+            and match.group("version") not in BASE_URL_PREFIXES.values()
+        ):
+            raise VersionNotSupported(
+                detail=(
+                    f"The parsed versioned base URL {match.group('version')!r} "
+                    f"from {url} is not supported by this implementation. "
+                    "Supported versioned base URLs are: "
+                    f"{', '.join(BASE_URL_PREFIXES.values())}"
                 )
+            )
 
-    async def dispatch(self, request: "Request", call_next):
+    async def dispatch(self, request: Request, call_next):
         if request.url.path:
             await self.check_url(request.url)
-        response = await call_next(request)
-        return response
+        return await call_next(request)

--- a/optimade_gateway/models/__init__.py
+++ b/optimade_gateway/models/__init__.py
@@ -4,6 +4,7 @@ Pydantic models
 All pydantic data and response models used to define the API can be found in this
 module.
 """
+from __future__ import annotations
 
 from .databases import DatabaseCreate
 from .gateways import GatewayCreate, GatewayResource, GatewayResourceAttributes

--- a/optimade_gateway/models/__init__.py
+++ b/optimade_gateway/models/__init__.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 
 from .databases import DatabaseCreate
 from .gateways import GatewayCreate, GatewayResource, GatewayResourceAttributes
-from .queries import GatewayQueryResponse, QueryCreate, QueryResource, QueryState
+from .queries import (
+    EndpointEntryType,
+    GatewayQueryResponse,
+    QueryCreate,
+    QueryResource,
+    QueryState,
+)
 from .resources import EntryResourceCreate
 from .responses import (
     DatabasesResponse,
@@ -24,6 +30,7 @@ __all__ = (
     "DatabaseCreate",
     "DatabasesResponse",
     "DatabasesResponseSingle",
+    "EndpointEntryType",
     "EntryResourceCreate",
     "GatewayCreate",
     "GatewayQueryResponse",

--- a/optimade_gateway/models/databases.py
+++ b/optimade_gateway/models/databases.py
@@ -1,12 +1,12 @@
 """Pydantic models/schemas for the LinksResource used in /databases"""
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Optional
 
-from optimade.models import Link, LinksResourceAttributes
-from optimade.models.links import LinkType
+from optimade.models import LinksResourceAttributes
+from optimade.models.links import LinkType, JsonLinkType
 from optimade.models.utils import StrictField
-from pydantic import AnyUrl, field_validator
+from pydantic import field_validator
 
 from optimade_gateway.models.resources import EntryResourceCreate
 
@@ -30,25 +30,22 @@ class DatabaseCreate(EntryResourceCreate, LinksResourceAttributes):
 
     """
 
-    description: str | None
-    base_url: AnyUrl | Link
+    description: Annotated[Optional[str], StrictField(description=LinksResourceAttributes.model_fields["description"].description)] = None
+
+    base_url: Annotated[JsonLinkType, StrictField(description=LinksResourceAttributes.model_fields["base_url"].description)]
+
     homepage: Annotated[
-        AnyUrl | Link | None,
+        Optional[JsonLinkType],
         StrictField(
-            description=(
-                "JSON API links object, pointing to a homepage URL for this "
-                "implementation."
-            ),
+            description=LinksResourceAttributes.model_fields["homepage"].description,
         ),
     ] = None
+
     link_type: Annotated[
-        LinkType | None,
+        Optional[LinkType],
         StrictField(
-            title="Link Type",
-            description=(
-                "The type of the linked relation.\nMUST be one of these values: "
-                "'child', 'root', 'external', 'providers'."
-            ),
+            title=LinksResourceAttributes.model_fields["link_type"].title,
+            description=LinksResourceAttributes.model_fields["link_type"].description,
         ),
     ] = None
 

--- a/optimade_gateway/models/databases.py
+++ b/optimade_gateway/models/databases.py
@@ -1,5 +1,5 @@
 """Pydantic models/schemas for the LinksResource used in /databases"""
-from typing import Optional, Union
+from __future__ import annotations
 
 from optimade.models import Link, LinksResourceAttributes
 from optimade.models.links import LinkType
@@ -28,15 +28,15 @@ class DatabaseCreate(EntryResourceCreate, LinksResourceAttributes):
 
     """
 
-    description: Optional[str]
-    base_url: Union[AnyUrl, Link]
-    homepage: Optional[Union[AnyUrl, Link]] = StrictField(
+    description: str | None
+    base_url: AnyUrl | Link
+    homepage: AnyUrl | Link | None = StrictField(
         None,
         description=(
             "JSON API links object, pointing to a homepage URL for this implementation."
         ),
     )
-    link_type: Optional[LinkType] = StrictField(
+    link_type: LinkType | None = StrictField(
         None,
         title="Link Type",
         description=(

--- a/optimade_gateway/models/databases.py
+++ b/optimade_gateway/models/databases.py
@@ -1,10 +1,10 @@
 """Pydantic models/schemas for the LinksResource used in /databases"""
 from __future__ import annotations
 
-from typing import Annotated, Optional
+from typing import Annotated
 
 from optimade.models import LinksResourceAttributes
-from optimade.models.links import LinkType, JsonLinkType
+from optimade.models.links import JsonLinkType, LinkType
 from optimade.models.utils import StrictField
 from pydantic import field_validator
 
@@ -30,19 +30,29 @@ class DatabaseCreate(EntryResourceCreate, LinksResourceAttributes):
 
     """
 
-    description: Annotated[Optional[str], StrictField(description=LinksResourceAttributes.model_fields["description"].description)] = None
+    description: Annotated[
+        str | None,
+        StrictField(
+            description=LinksResourceAttributes.model_fields["description"].description
+        ),
+    ] = None
 
-    base_url: Annotated[JsonLinkType, StrictField(description=LinksResourceAttributes.model_fields["base_url"].description)]
+    base_url: Annotated[
+        JsonLinkType,
+        StrictField(
+            description=LinksResourceAttributes.model_fields["base_url"].description
+        ),
+    ]
 
     homepage: Annotated[
-        Optional[JsonLinkType],
+        JsonLinkType | None,
         StrictField(
             description=LinksResourceAttributes.model_fields["homepage"].description,
         ),
     ] = None
 
     link_type: Annotated[
-        Optional[LinkType],
+        LinkType | None,
         StrictField(
             title=LinksResourceAttributes.model_fields["link_type"].title,
             description=LinksResourceAttributes.model_fields["link_type"].description,

--- a/optimade_gateway/models/databases.py
+++ b/optimade_gateway/models/databases.py
@@ -1,10 +1,12 @@
 """Pydantic models/schemas for the LinksResource used in /databases"""
 from __future__ import annotations
 
+from typing import Annotated
+
 from optimade.models import Link, LinksResourceAttributes
 from optimade.models.links import LinkType
 from optimade.models.utils import StrictField
-from pydantic import AnyUrl, validator
+from pydantic import AnyUrl, field_validator
 
 from optimade_gateway.models.resources import EntryResourceCreate
 
@@ -30,22 +32,28 @@ class DatabaseCreate(EntryResourceCreate, LinksResourceAttributes):
 
     description: str | None
     base_url: AnyUrl | Link
-    homepage: AnyUrl | Link | None = StrictField(
-        None,
-        description=(
-            "JSON API links object, pointing to a homepage URL for this implementation."
+    homepage: Annotated[
+        AnyUrl | Link | None,
+        StrictField(
+            description=(
+                "JSON API links object, pointing to a homepage URL for this "
+                "implementation."
+            ),
         ),
-    )
-    link_type: LinkType | None = StrictField(
-        None,
-        title="Link Type",
-        description=(
-            "The type of the linked relation.\nMUST be one of these values: 'child', "
-            "'root', 'external', 'providers'."
+    ] = None
+    link_type: Annotated[
+        LinkType | None,
+        StrictField(
+            title="Link Type",
+            description=(
+                "The type of the linked relation.\nMUST be one of these values: "
+                "'child', 'root', 'external', 'providers'."
+            ),
         ),
-    )
+    ] = None
 
-    @validator("link_type")
+    @field_validator("link_type", mode="after")
+    @classmethod
     def ensure_database_link_type(cls, value: LinkType) -> LinkType:
         """Ensure databases are not index meta-database-only types
 

--- a/optimade_gateway/models/gateways.py
+++ b/optimade_gateway/models/gateways.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import warnings
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Optional
 
 from optimade.models import EntryResource, EntryResourceAttributes, LinksResource
 from optimade.models.links import LinkType
-from optimade.models.utils import OptimadeField, SupportLevel
+from optimade.models.utils import OptimadeField
 from pydantic import Field, field_validator, model_validator
 
 from optimade_gateway.models.resources import EntryResourceCreate
@@ -85,72 +85,40 @@ class GatewayResource(EntryResource):
     id: Annotated[
         str,
         OptimadeField(
-            description="""An entry's ID as defined in section Definition of Terms.
-
-- **Type**: string.
-
-- **Requirements/Conventions**:
-    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.
-    - **Query**: MUST be a queryable property with support for all mandatory filter
-      features.
-    - **Response**: REQUIRED in the response.
-    - **Gateway-specific**: MUST NOT contain a forward slash (`/`).
-
-- **Examples**:
-    - `"db_1234567"`
-    - `"cod_2000000"`
-    - `"cod_2000000@1234567"`
-    - `"nomad_L1234567890"`
-    - `"42"`""",
-            support=SupportLevel.MUST,
-            queryable=SupportLevel.MUST,
+            description=EntryResource.model_fields["id"].description,
+            support=EntryResource.model_fields["id"].json_schema_extra["x-optimade-support"],
+            queryable=EntryResource.model_fields["id"].json_schema_extra["x-optimade-queryable"],
             pattern=r"^[^/]*$",
         ),
     ]
+
     type: Annotated[
         Literal["gateways"],
-        Field(
-            description="The name of the type of an entry.",
-        ),
+        Field(description="The name of the type of an entry."),
     ] = "gateways"
-    attributes: GatewayResourceAttributes
+
+    attributes: Annotated[GatewayResourceAttributes, Field(description=EntryResource.model_fields["attributes"].description)]
 
 
 class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
     """Model for creating new Gateway resources in the MongoDB"""
 
     id: Annotated[
-        str | None,
+        Optional[str],
         OptimadeField(
-            description="""An entry's ID as defined in section Definition of Terms.
-
-- **Type**: string.
-
-- **Requirements/Conventions**:
-    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.
-    - **Query**: MUST be a queryable property with support for all mandatory filter
-      features.
-    - **Response**: REQUIRED in the response.
-    - **Gateway-specific**: MUST NOT contain a forward slash (`/`).
-
-- **Examples**:
-    - `"db_1234567"`
-    - `"cod_2000000"`
-    - `"cod_2000000@1234567"`
-    - `"nomad_L1234567890"`
-    - `"42"`""",
-            support=SupportLevel.MUST,
-            queryable=SupportLevel.MUST,
-            pattern=r"^[^/]*$",  # This regex is the special addition
+            description=EntryResource.model_fields["id"].description,
+            support=EntryResource.model_fields["id"].json_schema_extra["x-optimade-support"],
+            queryable=EntryResource.model_fields["id"].json_schema_extra["x-optimade-queryable"],
+            pattern=r"^[^/]*$",  # This pattern is the special addition
         ),
     ] = None
 
     database_ids: Annotated[
-        set[str] | None,
+        Optional[set[str]],
         Field(description="A unique list of database IDs for registered databases."),
     ] = None
 
-    databases: list[LinksResource] | None  # type: ignore[assignment]
+    databases: Annotated[Optional[list[LinksResource]], Field(description=GatewayResourceAttributes.model_fields["databases"].description)] = None
 
     @model_validator(mode="after")
     def specify_databases(self) -> GatewayCreate:

--- a/optimade_gateway/models/gateways.py
+++ b/optimade_gateway/models/gateways.py
@@ -1,6 +1,7 @@
 """Pydantic models/schemas for the Gateways resource."""
+from __future__ import annotations
+
 import warnings
-from typing import List, Optional, Set
 
 from optimade.models import EntryResource, EntryResourceAttributes, LinksResource
 from optimade.models.links import LinkType
@@ -15,7 +16,7 @@ from optimade_gateway.warnings import OptimadeGatewayWarning
 class GatewayResourceAttributes(EntryResourceAttributes):
     """Attributes for an OPTIMADE gateway"""
 
-    databases: List[LinksResource] = Field(
+    databases: list[LinksResource] = Field(
         ...,
         description=(
             "List of databases (OPTIMADE 'links') to be queried in this gateway."
@@ -38,7 +39,7 @@ class GatewayResourceAttributes(EntryResourceAttributes):
         return value
 
     @validator("databases")
-    def unique_base_urls(cls, value: List[LinksResource]) -> List[LinksResource]:
+    def unique_base_urls(cls, value: list[LinksResource]) -> list[LinksResource]:
         """Remove extra entries with repeated base_urls"""
         db_base_urls = [_.attributes.base_url for _ in value]
         unique_base_urls = set(db_base_urls)
@@ -51,7 +52,7 @@ class GatewayResourceAttributes(EntryResourceAttributes):
         ]
         for base_url in repeated_base_urls:
             new_databases.append(
-                [_ for _ in value if _.attributes.base_url == base_url][0]
+                next(_ for _ in value if _.attributes.base_url == base_url)
             )
         warnings.warn(
             "Removed extra database entries for a gateway, because the base_url was "
@@ -113,7 +114,7 @@ class GatewayResource(EntryResource):
 class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
     """Model for creating new Gateway resources in the MongoDB"""
 
-    id: Optional[str] = OptimadeField(
+    id: str | None = OptimadeField(
         None,
         description="""An entry's ID as defined in section Definition of Terms.
 
@@ -137,11 +138,11 @@ class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
         regex=r"^[^/]*$",  # This regex is the special addition
     )
 
-    database_ids: Optional[Set[str]] = Field(
+    database_ids: set[str] | None = Field(
         None, description="A unique list of database IDs for registered databases."
     )
 
-    databases: Optional[List[LinksResource]]  # type: ignore
+    databases: list[LinksResource] | None
 
     @root_validator
     def specify_databases(cls, values: dict) -> dict:

--- a/optimade_gateway/models/gateways.py
+++ b/optimade_gateway/models/gateways.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Literal
 
 from optimade.models import EntryResource, EntryResourceAttributes, LinksResource
 from optimade.models.links import LinkType
@@ -86,8 +86,12 @@ class GatewayResource(EntryResource):
         str,
         OptimadeField(
             description=EntryResource.model_fields["id"].description,
-            support=EntryResource.model_fields["id"].json_schema_extra["x-optimade-support"],
-            queryable=EntryResource.model_fields["id"].json_schema_extra["x-optimade-queryable"],
+            support=EntryResource.model_fields["id"].json_schema_extra[
+                "x-optimade-support"
+            ],
+            queryable=EntryResource.model_fields["id"].json_schema_extra[
+                "x-optimade-queryable"
+            ],
             pattern=r"^[^/]*$",
         ),
     ]
@@ -97,28 +101,40 @@ class GatewayResource(EntryResource):
         Field(description="The name of the type of an entry."),
     ] = "gateways"
 
-    attributes: Annotated[GatewayResourceAttributes, Field(description=EntryResource.model_fields["attributes"].description)]
+    attributes: Annotated[
+        GatewayResourceAttributes,
+        Field(description=EntryResource.model_fields["attributes"].description),
+    ]
 
 
 class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
     """Model for creating new Gateway resources in the MongoDB"""
 
     id: Annotated[
-        Optional[str],
+        str | None,
         OptimadeField(
             description=EntryResource.model_fields["id"].description,
-            support=EntryResource.model_fields["id"].json_schema_extra["x-optimade-support"],
-            queryable=EntryResource.model_fields["id"].json_schema_extra["x-optimade-queryable"],
+            support=EntryResource.model_fields["id"].json_schema_extra[
+                "x-optimade-support"
+            ],
+            queryable=EntryResource.model_fields["id"].json_schema_extra[
+                "x-optimade-queryable"
+            ],
             pattern=r"^[^/]*$",  # This pattern is the special addition
         ),
     ] = None
 
     database_ids: Annotated[
-        Optional[set[str]],
+        set[str] | None,
         Field(description="A unique list of database IDs for registered databases."),
     ] = None
 
-    databases: Annotated[Optional[list[LinksResource]], Field(description=GatewayResourceAttributes.model_fields["databases"].description)] = None
+    databases: Annotated[
+        list[LinksResource] | None,
+        Field(
+            description=GatewayResourceAttributes.model_fields["databases"].description
+        ),
+    ] = None
 
     @model_validator(mode="after")
     def specify_databases(self) -> GatewayCreate:

--- a/optimade_gateway/models/gateways.py
+++ b/optimade_gateway/models/gateways.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import warnings
+from typing import Annotated, Literal
 
 from optimade.models import EntryResource, EntryResourceAttributes, LinksResource
 from optimade.models.links import LinkType
 from optimade.models.utils import OptimadeField, SupportLevel
-from pydantic import Field, validator
-from pydantic.class_validators import root_validator
+from pydantic import Field, field_validator, model_validator
 
 from optimade_gateway.models.resources import EntryResourceCreate
 from optimade_gateway.warnings import OptimadeGatewayWarning
@@ -16,31 +16,34 @@ from optimade_gateway.warnings import OptimadeGatewayWarning
 class GatewayResourceAttributes(EntryResourceAttributes):
     """Attributes for an OPTIMADE gateway"""
 
-    databases: list[LinksResource] = Field(
-        ...,
-        description=(
-            "List of databases (OPTIMADE 'links') to be queried in this gateway."
+    databases: Annotated[
+        list[LinksResource],
+        Field(
+            description=(
+                "List of databases (OPTIMADE 'links') to be queried in this gateway."
+            ),
         ),
-    )
+    ]
 
-    @validator("databases", each_item=True)
-    def no_index_databases(cls, value: LinksResource) -> LinksResource:
-        """Ensure databases are not of type `"root"` or `"providers"`
+    @field_validator("databases", mode="after")
+    @classmethod
+    def unique_base_urls(cls, value: list[LinksResource]) -> list[LinksResource]:
+        """Remove extra entries with repeated base_urls.
+
+        Also, ensure databases are not of type `"root"` or `"providers"`
 
         !!! note
             Both `"external"` and `"child"` can still represent index meta-dbs,
             but `"root"` and `"providers"` can not represent "regular" dbs.
-        """
-        if value.attributes.link_type in (LinkType.ROOT, LinkType.PROVIDERS):
-            raise ValueError(
-                "Databases with 'root' or 'providers' link_type is not allowed for "
-                f"gateway resources. Given database: {value}"
-            )
-        return value
 
-    @validator("databases")
-    def unique_base_urls(cls, value: list[LinksResource]) -> list[LinksResource]:
-        """Remove extra entries with repeated base_urls"""
+        """
+        for resource in value:
+            if resource.attributes.link_type in (LinkType.ROOT, LinkType.PROVIDERS):
+                raise ValueError(
+                    "Databases with 'root' or 'providers' link_type is not allowed for "
+                    f"gateway resources. Given database: {resource}"
+                )
+
         db_base_urls = [_.attributes.base_url for _ in value]
         unique_base_urls = set(db_base_urls)
         if len(db_base_urls) == len(unique_base_urls):
@@ -79,9 +82,10 @@ class GatewayResource(EntryResource):
     the originating database.
     """
 
-    id: str = OptimadeField(
-        ...,
-        description="""An entry's ID as defined in section Definition of Terms.
+    id: Annotated[
+        str,
+        OptimadeField(
+            description="""An entry's ID as defined in section Definition of Terms.
 
 - **Type**: string.
 
@@ -98,25 +102,27 @@ class GatewayResource(EntryResource):
     - `"cod_2000000@1234567"`
     - `"nomad_L1234567890"`
     - `"42"`""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.MUST,
-        regex=r"^[^/]*$",
-    )
-    type: str = Field(
-        "gateways",
-        const=True,
-        description="The name of the type of an entry.",
-        regex="^gateways$",
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.MUST,
+            pattern=r"^[^/]*$",
+        ),
+    ]
+    type: Annotated[
+        Literal["gateways"],
+        Field(
+            description="The name of the type of an entry.",
+        ),
+    ] = "gateways"
     attributes: GatewayResourceAttributes
 
 
 class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
     """Model for creating new Gateway resources in the MongoDB"""
 
-    id: str | None = OptimadeField(
-        None,
-        description="""An entry's ID as defined in section Definition of Terms.
+    id: Annotated[
+        str | None,
+        OptimadeField(
+            description="""An entry's ID as defined in section Definition of Terms.
 
 - **Type**: string.
 
@@ -133,22 +139,24 @@ class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
     - `"cod_2000000@1234567"`
     - `"nomad_L1234567890"`
     - `"42"`""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.MUST,
-        regex=r"^[^/]*$",  # This regex is the special addition
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.MUST,
+            pattern=r"^[^/]*$",  # This regex is the special addition
+        ),
+    ] = None
 
-    database_ids: set[str] | None = Field(
-        None, description="A unique list of database IDs for registered databases."
-    )
+    database_ids: Annotated[
+        set[str] | None,
+        Field(description="A unique list of database IDs for registered databases."),
+    ] = None
 
-    databases: list[LinksResource] | None
+    databases: list[LinksResource] | None  # type: ignore[assignment]
 
-    @root_validator
-    def specify_databases(cls, values: dict) -> dict:
+    @model_validator(mode="after")
+    def specify_databases(self) -> GatewayCreate:
         """Either `database_ids` or `databases` must be non-empty.
         Both together is also fine.
         """
-        if not any(values.get(field) for field in ("database_ids", "databases")):
+        if not any(getattr(self, field) for field in ("database_ids", "databases")):
             raise ValueError("Either 'database_ids' or 'databases' MUST be specified")
-        return values
+        return self

--- a/optimade_gateway/models/gateways.py
+++ b/optimade_gateway/models/gateways.py
@@ -134,7 +134,7 @@ class GatewayCreate(EntryResourceCreate, GatewayResourceAttributes):
         Field(
             description=GatewayResourceAttributes.model_fields["databases"].description
         ),
-    ] = None
+    ] = None  # type: ignore[assignment]
 
     @model_validator(mode="after")
     def specify_databases(self) -> GatewayCreate:

--- a/optimade_gateway/models/queries.py
+++ b/optimade_gateway/models/queries.py
@@ -1,10 +1,12 @@
 """Pydantic models/schemas for the Queries resource."""
+from __future__ import annotations
+
 import urllib.parse
 import warnings
 from copy import deepcopy
 from datetime import timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from optimade.models import EntryResource as OptimadeEntryResource
 from optimade.models import (
@@ -38,7 +40,7 @@ class EndpointEntryType(Enum):
     REFERENCES = "references"
     STRUCTURES = "structures"
 
-    def get_resource_model(self) -> Union[ReferenceResource, StructureResource]:
+    def get_resource_model(self) -> ReferenceResource | StructureResource:
         """Get the matching pydantic model for a resource."""
         return {
             "references": ReferenceResource,
@@ -47,12 +49,12 @@ class EndpointEntryType(Enum):
 
     def get_response_model(
         self, single: bool = False
-    ) -> Union[
-        ReferenceResponseMany,
-        ReferenceResponseOne,
-        StructureResponseMany,
-        StructureResponseOne,
-    ]:
+    ) -> (
+        ReferenceResponseMany
+        | ReferenceResponseOne
+        | StructureResponseMany
+        | StructureResponseOne
+    ):
         """Get the matching pydantic model for a successful response."""
         if single:
             return {
@@ -73,59 +75,59 @@ QUERY_PARAMETERS = EntryListingQueryParams()
 class OptimadeQueryParameters(BaseModel):
     """Common OPTIMADE entry listing endpoint query parameters."""
 
-    filter: Optional[str] = Field(
+    filter: str | None = Field(
         QUERY_PARAMETERS.filter.default,
         description=QUERY_PARAMETERS.filter.description,
     )
-    response_format: Optional[str] = Field(
+    response_format: str | None = Field(
         QUERY_PARAMETERS.response_format.default,
         description=QUERY_PARAMETERS.response_format.description,
     )
-    email_address: Optional[EmailStr] = Field(
+    email_address: EmailStr | None = Field(
         QUERY_PARAMETERS.email_address.default,
         description=QUERY_PARAMETERS.email_address.description,
     )
-    response_fields: Optional[str] = Field(
+    response_fields: str | None = Field(
         QUERY_PARAMETERS.response_fields.default,
         description=QUERY_PARAMETERS.response_fields.description,
         regex=QUERY_PARAMETERS.response_fields.regex,
     )
-    sort: Optional[str] = Field(
+    sort: str | None = Field(
         QUERY_PARAMETERS.sort.default,
         description=QUERY_PARAMETERS.sort.description,
         regex=QUERY_PARAMETERS.sort.regex,
     )
-    page_limit: Optional[int] = Field(
+    page_limit: int | None = Field(
         QUERY_PARAMETERS.page_limit.default,
         description=QUERY_PARAMETERS.page_limit.description,
         ge=QUERY_PARAMETERS.page_limit.ge,
     )
-    page_offset: Optional[int] = Field(
+    page_offset: int | None = Field(
         QUERY_PARAMETERS.page_offset.default,
         description=QUERY_PARAMETERS.page_offset.description,
         ge=QUERY_PARAMETERS.page_offset.ge,
     )
-    page_number: Optional[int] = Field(
+    page_number: int | None = Field(
         QUERY_PARAMETERS.page_number.default,
         description=QUERY_PARAMETERS.page_number.description,
         ge=QUERY_PARAMETERS.page_number.ge,
     )
-    page_cursor: Optional[int] = Field(
+    page_cursor: int | None = Field(
         QUERY_PARAMETERS.page_cursor.default,
         description=QUERY_PARAMETERS.page_cursor.description,
         ge=QUERY_PARAMETERS.page_cursor.ge,
     )
-    page_above: Optional[int] = Field(
+    page_above: int | None = Field(
         QUERY_PARAMETERS.page_above.default,
         description=QUERY_PARAMETERS.page_above.description,
         ge=QUERY_PARAMETERS.page_above.ge,
     )
-    page_below: Optional[int] = Field(
+    page_below: int | None = Field(
         QUERY_PARAMETERS.page_below.default,
         description=QUERY_PARAMETERS.page_below.description,
         ge=QUERY_PARAMETERS.page_below.ge,
     )
-    include: Optional[str] = Field(
+    include: str | None = Field(
         QUERY_PARAMETERS.include.default,
         description=QUERY_PARAMETERS.include.description,
     )
@@ -164,13 +166,13 @@ class EntryResource(OptimadeEntryResource):
 class GatewayQueryResponse(Response):
     """Response from a Gateway Query."""
 
-    data: Dict[str, Union[List[EntryResource], List[Dict[str, Any]]]] = StrictField(
+    data: dict[str, list[EntryResource] | list[dict[str, Any]]] = StrictField(
         ..., uniqueItems=True, description="Outputted Data."
     )
     meta: ResponseMeta = StrictField(
         ..., description="A meta object containing non-standard information."
     )
-    errors: Optional[List[OptimadeError]] = StrictField(
+    errors: list[OptimadeError] | None = StrictField(
         [],
         description=(
             "A list of OPTIMADE-specific JSON API error objects, where the field "
@@ -178,7 +180,7 @@ class GatewayQueryResponse(Response):
         ),
         uniqueItems=True,
     )
-    included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(
+    included: list[EntryResource] | list[dict[str, Any]] | None = Field(
         None, uniqueItems=True
     )
 
@@ -222,7 +224,7 @@ class QueryResourceAttributes(EntryResourceAttributes):
         title="State",
         type="enum",
     )
-    response: Optional[GatewayQueryResponse] = Field(
+    response: GatewayQueryResponse | None = Field(
         None,
         description="Response from gateway query.",
     )
@@ -257,10 +259,11 @@ class QueryResource(EntryResource):
 
     async def response_as_optimade(
         self,
-        url: Optional[
-            Union[urllib.parse.ParseResult, urllib.parse.SplitResult, StarletteURL, str]
-        ] = None,
-    ) -> Union[EntryResponseMany, ErrorResponse]:
+        url: None
+        | (
+            urllib.parse.ParseResult | urllib.parse.SplitResult | StarletteURL | str
+        ) = None,
+    ) -> EntryResponseMany | ErrorResponse:
         """Return `attributes.response` as a valid OPTIMADE entry listing response.
 
         Note, this method disregards the state of the query and will simply return the
@@ -280,8 +283,8 @@ class QueryResource(EntryResource):
         )
 
         async def _update_id(
-            entry_: Union[EntryResource, Dict[str, Any]], database_provider_: str
-        ) -> Union[EntryResource, Dict[str, Any]]:
+            entry_: EntryResource | dict[str, Any], database_provider_: str
+        ) -> EntryResource | dict[str, Any]:
             """Internal utility function to prepend the entries' `id` with
             `provider/database/`.
 
@@ -360,8 +363,8 @@ class QueryResource(EntryResource):
 class QueryCreate(EntryResourceCreate, QueryResourceAttributes):
     """Model for creating new Query resources in the MongoDB"""
 
-    state: Optional[QueryState]  # type: ignore[assignment]
-    endpoint: Optional[EndpointEntryType]  # type: ignore[assignment]
+    state: QueryState | None  # type: ignore[assignment]
+    endpoint: EndpointEntryType | None  # type: ignore[assignment]
 
     @validator("query_parameters")
     def sort_not_supported(

--- a/optimade_gateway/models/queries.py
+++ b/optimade_gateway/models/queries.py
@@ -7,7 +7,7 @@ import warnings
 from copy import deepcopy
 from datetime import timezone
 from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from optimade.models import EntryResource as OptimadeEntryResource
 from optimade.models import (
@@ -31,7 +31,6 @@ from pydantic.fields import FieldInfo
 from starlette.datastructures import URL as StarletteURL
 
 from optimade_gateway.common.config import CONFIG
-from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.models.resources import EntryResourceCreate
 from optimade_gateway.warnings import SortNotSupported
 
@@ -447,16 +446,26 @@ class QueryResource(EntryResource):
 class QueryCreate(EntryResourceCreate, QueryResourceAttributes):
     """Model for creating new Query resources in the MongoDB"""
 
-    state: Annotated[Optional[QueryState], Field(
-        title=QueryResourceAttributes.model_fields["state"].title,
-        description=QueryResourceAttributes.model_fields["state"].description,
-        json_schema_extra=QueryResourceAttributes.model_fields["state"].json_schema_extra,
-    )] = None
-    endpoint: Annotated[Optional[EndpointEntryType], Field(
-        title=QueryResourceAttributes.model_fields["endpoint"].title,
-        description=QueryResourceAttributes.model_fields["endpoint"].description,
-        json_schema_extra=QueryResourceAttributes.model_fields["endpoint"].json_schema_extra,
-    )] = None
+    state: Annotated[
+        QueryState | None,
+        Field(
+            title=QueryResourceAttributes.model_fields["state"].title,
+            description=QueryResourceAttributes.model_fields["state"].description,
+            json_schema_extra=QueryResourceAttributes.model_fields[
+                "state"
+            ].json_schema_extra,
+        ),
+    ] = None
+    endpoint: Annotated[
+        EndpointEntryType | None,
+        Field(
+            title=QueryResourceAttributes.model_fields["endpoint"].title,
+            description=QueryResourceAttributes.model_fields["endpoint"].description,
+            json_schema_extra=QueryResourceAttributes.model_fields[
+                "endpoint"
+            ].json_schema_extra,
+        ),
+    ] = None
 
     @field_validator("query_parameters", mode="after")
     @classmethod

--- a/optimade_gateway/models/queries.py
+++ b/optimade_gateway/models/queries.py
@@ -455,7 +455,7 @@ class QueryCreate(EntryResourceCreate, QueryResourceAttributes):
                 "state"
             ].json_schema_extra,
         ),
-    ] = None
+    ] = None  # type: ignore[assignment]
     endpoint: Annotated[
         EndpointEntryType | None,
         Field(
@@ -465,7 +465,7 @@ class QueryCreate(EntryResourceCreate, QueryResourceAttributes):
                 "endpoint"
             ].json_schema_extra,
         ),
-    ] = None
+    ] = None  # type: ignore[assignment]
 
     @field_validator("query_parameters", mode="after")
     @classmethod

--- a/optimade_gateway/models/resources.py
+++ b/optimade_gateway/models/resources.py
@@ -6,7 +6,6 @@ mix-in class when creating entry-endpoint resources.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
 
 from optimade.models import EntryResourceAttributes
 from pydantic import ConfigDict, model_validator
@@ -17,9 +16,9 @@ class EntryResourceCreate(EntryResourceAttributes):
 
     model_config = ConfigDict(extra="ignore")
 
-    last_modified: Optional[datetime] = None
+    last_modified: datetime | None = None
 
-    id: Optional[str] = None
+    id: str | None = None
 
     @model_validator(mode="after")
     def check_illegal_attributes_fields(self) -> EntryResourceCreate:

--- a/optimade_gateway/models/resources.py
+++ b/optimade_gateway/models/resources.py
@@ -9,19 +9,17 @@ from datetime import datetime
 from typing import Any
 
 from optimade.models import EntryResourceAttributes
+from pydantic import ConfigDict
 
 
 class EntryResourceCreate(EntryResourceAttributes):
     """Generic model for creating new entry resources in the MongoDB"""
 
+    model_config = ConfigDict(extra="ignore")
+
     last_modified: datetime | None
 
     id: str | None
-
-    class Config:
-        """Silently discard extra initiation keys."""
-
-        extra = "ignore"
 
     @classmethod
     def _remove_pre_root_validators(cls):

--- a/optimade_gateway/models/resources.py
+++ b/optimade_gateway/models/resources.py
@@ -3,8 +3,10 @@
 This module is mainly used for a special pydantic base model, which can be used as a
 mix-in class when creating entry-endpoint resources.
 """
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from optimade.models import EntryResourceAttributes
 
@@ -12,9 +14,9 @@ from optimade.models import EntryResourceAttributes
 class EntryResourceCreate(EntryResourceAttributes):
     """Generic model for creating new entry resources in the MongoDB"""
 
-    last_modified: Optional[datetime]
+    last_modified: datetime | None
 
-    id: Optional[str]
+    id: str | None
 
     class Config:
         """Silently discard extra initiation keys."""

--- a/optimade_gateway/models/resources.py
+++ b/optimade_gateway/models/resources.py
@@ -6,10 +6,10 @@ mix-in class when creating entry-endpoint resources.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Optional
 
 from optimade.models import EntryResourceAttributes
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 
 
 class EntryResourceCreate(EntryResourceAttributes):
@@ -17,22 +17,11 @@ class EntryResourceCreate(EntryResourceAttributes):
 
     model_config = ConfigDict(extra="ignore")
 
-    last_modified: datetime | None
+    last_modified: Optional[datetime] = None
 
-    id: str | None
+    id: Optional[str] = None
 
-    @classmethod
-    def _remove_pre_root_validators(cls):
-        """Remove `check_illegal_attributes_fields` pre root_validators."""
-        pre_root_validators = []
-        for validator in cls.__pre_root_validators__:
-            if not str(validator).startswith(
-                "<function Attributes.check_illegal_attributes_fields"
-            ):
-                pre_root_validators.append(validator)
-        cls.__pre_root_validators__ = pre_root_validators
-
-    def __init__(self, **data: Any) -> None:
-        """Remove root_validator `check_illegal_attributes_fields`."""
-        self._remove_pre_root_validators()
-        super().__init__(**data)
+    @model_validator(mode="after")
+    def check_illegal_attributes_fields(self) -> EntryResourceCreate:
+        """Overwrite parental `check_illegal_attributes_fields` class validators."""
+        return self

--- a/optimade_gateway/models/responses.py
+++ b/optimade_gateway/models/responses.py
@@ -1,5 +1,5 @@
 """Pydantic models/schemas for the API responses."""
-from typing import List, Optional
+from __future__ import annotations
 
 from optimade.models import EntryResponseMany, EntryResponseOne, LinksResource
 from pydantic import Field
@@ -13,10 +13,10 @@ class DatabasesResponse(EntryResponseMany):
 
     This model is essentially equal to
     [`LinksResponse`](https://www.optimade.org/optimade-python-tools/api_reference/models/responses/#optimade.models.responses.LinksResponse)
-    with the exception of the `data´ field's description.
+    with the exception of the `data` field's description.
     """
 
-    data: List[LinksResource] = Field(
+    data: list[LinksResource] = Field(
         ...,
         description=(
             "List of unique OPTIMADE links resource objects.\nThese links resource "
@@ -30,7 +30,7 @@ class DatabasesResponse(EntryResponseMany):
 class DatabasesResponseSingle(EntryResponseOne):
     """Successful response for `POST /databases` and `GET /databases/{database_id}`"""
 
-    data: Optional[LinksResource] = Field(
+    data: LinksResource | None = Field(
         ...,
         description=(
             "A unique OPTIMADE links resource object.\nThe OPTIMADE links resource "
@@ -44,7 +44,7 @@ class DatabasesResponseSingle(EntryResponseOne):
 class GatewaysResponse(EntryResponseMany):
     """Successful response for `GET /gateways`"""
 
-    data: List[GatewayResource] = Field(
+    data: list[GatewayResource] = Field(
         ...,
         description="""List of unique OPTIMADE gateway resource objects.""",
         uniqueItems=True,
@@ -54,7 +54,7 @@ class GatewaysResponse(EntryResponseMany):
 class GatewaysResponseSingle(EntryResponseOne):
     """Successful response for `POST /gateways` and `GET /gateways/{gateway_id}`."""
 
-    data: Optional[GatewayResource] = Field(
+    data: GatewayResource | None = Field(
         ...,
         description=(
             "A unique OPTIMADE gateway resource object.\nThe OPTIMADE gateway resource "
@@ -67,7 +67,7 @@ class GatewaysResponseSingle(EntryResponseOne):
 class QueriesResponse(EntryResponseMany):
     """Successful response for `GET /gateways/{gateway_ID}/queries`."""
 
-    data: List[QueryResource] = Field(
+    data: list[QueryResource] = Field(
         ...,
         description="List of unique OPTIMADE gateway query resource objects.",
         uniqueItems=True,
@@ -78,7 +78,7 @@ class QueriesResponseSingle(EntryResponseOne):
     """Successful response for `POST /gateways/{gateway_ID}/queries`
     and `GET /gateways/{gateway_ID}/queries/{query_id}`."""
 
-    data: Optional[QueryResource] = Field(
+    data: QueryResource | None = Field(
         ...,
         description=(
             "A unique OPTIMADE gateway query resource object.\nThe OPTIMADE gateway "

--- a/optimade_gateway/models/responses.py
+++ b/optimade_gateway/models/responses.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from optimade.models import EntryResponseMany, EntryResponseOne, LinksResource
+from optimade.models.utils import StrictField
 from pydantic import Field
 
 from optimade_gateway.models.gateways import GatewayResource
@@ -20,7 +21,7 @@ class DatabasesResponse(EntryResponseMany):
 
     data: Annotated[
         list[LinksResource],
-        Field(
+        StrictField(
             description=(
                 "List of unique OPTIMADE links resource objects.\nThese links resource "
                 "objects represents OPTIMADE databases that can be used for queries in "
@@ -52,7 +53,7 @@ class GatewaysResponse(EntryResponseMany):
 
     data: Annotated[
         list[GatewayResource],
-        Field(
+        StrictField(
             description="""List of unique OPTIMADE gateway resource objects.""",
             uniqueItems=True,
         ),
@@ -79,7 +80,7 @@ class QueriesResponse(EntryResponseMany):
 
     data: Annotated[
         list[QueryResource],
-        Field(
+        StrictField(
             description="List of unique OPTIMADE gateway query resource objects.",
             uniqueItems=True,
         ),

--- a/optimade_gateway/models/responses.py
+++ b/optimade_gateway/models/responses.py
@@ -54,7 +54,7 @@ class GatewaysResponse(EntryResponseMany):
     data: Annotated[
         list[GatewayResource],
         StrictField(
-            description="""List of unique OPTIMADE gateway resource objects.""",
+            description="List of unique OPTIMADE gateway resource objects.",
             uniqueItems=True,
         ),
     ]

--- a/optimade_gateway/models/responses.py
+++ b/optimade_gateway/models/responses.py
@@ -1,6 +1,8 @@
 """Pydantic models/schemas for the API responses."""
 from __future__ import annotations
 
+from typing import Annotated
+
 from optimade.models import EntryResponseMany, EntryResponseOne, LinksResource
 from pydantic import Field
 
@@ -16,73 +18,85 @@ class DatabasesResponse(EntryResponseMany):
     with the exception of the `data` field's description.
     """
 
-    data: list[LinksResource] = Field(
-        ...,
-        description=(
-            "List of unique OPTIMADE links resource objects.\nThese links resource "
-            "objects represents OPTIMADE databases that can be used for queries in "
-            "gateways."
+    data: Annotated[
+        list[LinksResource],
+        Field(
+            description=(
+                "List of unique OPTIMADE links resource objects.\nThese links resource "
+                "objects represents OPTIMADE databases that can be used for queries in "
+                "gateways."
+            ),
+            uniqueItems=True,
         ),
-        uniqueItems=True,
-    )
+    ]
 
 
 class DatabasesResponseSingle(EntryResponseOne):
     """Successful response for `POST /databases` and `GET /databases/{database_id}`"""
 
-    data: LinksResource | None = Field(
-        ...,
-        description=(
-            "A unique OPTIMADE links resource object.\nThe OPTIMADE links resource "
-            "object has just been created or found according to the specific query "
-            "parameter(s) or URL id.\nIt represents an OPTIMADE database that can be "
-            "used for queries in gateways."
+    data: Annotated[
+        LinksResource | None,
+        Field(
+            description=(
+                "A unique OPTIMADE links resource object.\nThe OPTIMADE links resource "
+                "object has just been created or found according to the specific query "
+                "parameter(s) or URL id.\nIt represents an OPTIMADE database that can "
+                "be used for queries in gateways."
+            ),
         ),
-    )
+    ]
 
 
 class GatewaysResponse(EntryResponseMany):
     """Successful response for `GET /gateways`"""
 
-    data: list[GatewayResource] = Field(
-        ...,
-        description="""List of unique OPTIMADE gateway resource objects.""",
-        uniqueItems=True,
-    )
+    data: Annotated[
+        list[GatewayResource],
+        Field(
+            description="""List of unique OPTIMADE gateway resource objects.""",
+            uniqueItems=True,
+        ),
+    ]
 
 
 class GatewaysResponseSingle(EntryResponseOne):
     """Successful response for `POST /gateways` and `GET /gateways/{gateway_id}`."""
 
-    data: GatewayResource | None = Field(
-        ...,
-        description=(
-            "A unique OPTIMADE gateway resource object.\nThe OPTIMADE gateway resource "
-            "object has just been created or found according to the specific query "
-            "parameter(s) or URL id."
+    data: Annotated[
+        GatewayResource | None,
+        Field(
+            description=(
+                "A unique OPTIMADE gateway resource object.\nThe OPTIMADE gateway "
+                "resource object has just been created or found according to the "
+                "specific query parameter(s) or URL id."
+            ),
         ),
-    )
+    ]
 
 
 class QueriesResponse(EntryResponseMany):
     """Successful response for `GET /gateways/{gateway_ID}/queries`."""
 
-    data: list[QueryResource] = Field(
-        ...,
-        description="List of unique OPTIMADE gateway query resource objects.",
-        uniqueItems=True,
-    )
+    data: Annotated[
+        list[QueryResource],
+        Field(
+            description="List of unique OPTIMADE gateway query resource objects.",
+            uniqueItems=True,
+        ),
+    ]
 
 
 class QueriesResponseSingle(EntryResponseOne):
     """Successful response for `POST /gateways/{gateway_ID}/queries`
     and `GET /gateways/{gateway_ID}/queries/{query_id}`."""
 
-    data: QueryResource | None = Field(
-        ...,
-        description=(
-            "A unique OPTIMADE gateway query resource object.\nThe OPTIMADE gateway "
-            "query resource object has just been created or found according to the "
-            "specific query parameter(s) or URL id."
+    data: Annotated[
+        QueryResource | None,
+        Field(
+            description=(
+                "A unique OPTIMADE gateway query resource object.\nThe OPTIMADE "
+                "gateway query resource object has just been created or found "
+                "according to the specific query parameter(s) or URL id."
+            ),
         ),
-    )
+    ]

--- a/optimade_gateway/models/search.py
+++ b/optimade_gateway/models/search.py
@@ -1,6 +1,7 @@
 """Pydantic models/schemas for the Search resource."""
+from __future__ import annotations
+
 import warnings
-from typing import Set
 
 from pydantic import AnyUrl, BaseModel, Field, root_validator, validator
 
@@ -22,14 +23,14 @@ class Search(BaseModel):
             "OPTIMADE query parameters for entry listing endpoints used for this query."
         ),
     )
-    database_ids: Set[str] = Field(
+    database_ids: set[str] = Field(
         set(),
         description=(
             "A list of registered database IDs. Go to `/databases` to get all "
             "registered databases."
         ),
     )
-    optimade_urls: Set[AnyUrl] = Field(
+    optimade_urls: set[AnyUrl] = Field(
         set(),
         description=(
             "A list of OPTIMADE base URLs. If a versioned base URL is supplied it will "

--- a/optimade_gateway/models/search.py
+++ b/optimade_gateway/models/search.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import warnings
+from typing import Annotated
 
-from pydantic import AnyUrl, BaseModel, Field, root_validator, validator
+from pydantic import AnyUrl, BaseModel, Field, field_validator, model_validator
 
 from optimade_gateway.models.queries import OptimadeQueryParameters
 from optimade_gateway.warnings import SortNotSupported
@@ -17,48 +18,62 @@ class Search(BaseModel):
 
     """
 
-    query_parameters: OptimadeQueryParameters = Field(
-        {},
-        description=(
-            "OPTIMADE query parameters for entry listing endpoints used for this query."
+    query_parameters: Annotated[
+        OptimadeQueryParameters,
+        Field(
+            description=(
+                "OPTIMADE query parameters for entry listing endpoints used for this "
+                "query."
+            ),
         ),
-    )
-    database_ids: set[str] = Field(
-        set(),
-        description=(
-            "A list of registered database IDs. Go to `/databases` to get all "
-            "registered databases."
-        ),
-    )
-    optimade_urls: set[AnyUrl] = Field(
-        set(),
-        description=(
-            "A list of OPTIMADE base URLs. If a versioned base URL is supplied it will "
-            "be used as is, as long as it represents a supported version. If an "
-            "un-versioned base URL, standard version negotiation will be conducted to "
-            "get the versioned base URL, which will be used as long as it represents a "
-            "supported version. Note, a single URL can be supplied as well, and it will"
-            " automatically be wrapped in a list in the server logic."
-        ),
-    )
-    endpoint: str = Field(
-        "structures",
-        description=(
-            "The entry endpoint queried. According to the OPTIMADE specification, this "
-            "is the same as the resource's type."
-        ),
-    )
+    ] = OptimadeQueryParameters()
 
-    @root_validator
-    def either_ids_or_urls(cls, values: dict) -> dict:
+    database_ids: Annotated[
+        set[str],
+        Field(
+            description=(
+                "A list of registered database IDs. Go to `/databases` to get all "
+                "registered databases."
+            ),
+        ),
+    ] = set()
+
+    optimade_urls: Annotated[
+        set[AnyUrl],
+        Field(
+            description=(
+                "A list of OPTIMADE base URLs. If a versioned base URL is supplied it "
+                "will be used as is, as long as it represents a supported version. If "
+                "an un-versioned base URL, standard version negotiation will be "
+                "conducted to get the versioned base URL, which will be used as long "
+                "as it represents a supported version. Note, a single URL can be "
+                "supplied as well, and it will automatically be wrapped in a list in "
+                "the server logic."
+            ),
+        ),
+    ] = set()
+
+    endpoint: Annotated[
+        str,
+        Field(
+            description=(
+                "The entry endpoint queried. According to the OPTIMADE specification, "
+                "this is the same as the resource's type."
+            ),
+        ),
+    ] = "structures"
+
+    @model_validator(mode="after")
+    def either_ids_or_urls(self) -> Search:
         """Either `database_ids` or `optimade_urls` must be defined"""
-        if not any(values.get(field) for field in ("database_ids", "optimade_urls")):
+        if not any(getattr(self, field) for field in ("database_ids", "optimade_urls")):
             raise ValueError(
                 "Either 'database_ids' or 'optimade_urls' MUST be specified."
             )
-        return values
+        return self
 
-    @validator("query_parameters")
+    @field_validator("query_parameters", mode="after")
+    @classmethod
     def sort_not_supported(
         cls, value: OptimadeQueryParameters
     ) -> OptimadeQueryParameters:

--- a/optimade_gateway/mongo/__init__.py
+++ b/optimade_gateway/mongo/__init__.py
@@ -1,4 +1,6 @@
 """Everything to do with the MongoDB backend."""
+from __future__ import annotations
+
 from .collection import AsyncMongoCollection
 
 __all__ = ("AsyncMongoCollection",)

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -481,7 +481,7 @@ class AsyncMongoCollection(EntryCollection):
         """
         resource.last_modified = datetime.utcnow()
         result = await self.collection.insert_one(
-            await clean_python_types(resource.dict(exclude_unset=True))
+            await clean_python_types(resource.model_dump(exclude_unset=True))
         )
         LOGGER.debug(
             "Inserted resource %r in DB collection %s with ID %s",

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -6,7 +6,7 @@ represents an asynchronous version of the equivalent MongoDB collection in `opti
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from os import getenv
 from typing import TYPE_CHECKING
 from warnings import warn
@@ -479,7 +479,7 @@ class AsyncMongoCollection(EntryCollection):
             The newly created document as a pydantic model entry resource.
 
         """
-        resource.last_modified = datetime.utcnow()
+        resource.last_modified = datetime.now(timezone.utc)
         result = await self.collection.insert_one(
             await clean_python_types(resource.model_dump(exclude_unset=True))
         )

--- a/optimade_gateway/mongo/collection.py
+++ b/optimade_gateway/mongo/collection.py
@@ -4,6 +4,8 @@ The [`AsyncMongoCollection`][optimade_gateway.mongo.collection.AsyncMongoCollect
 represents an asynchronous version of the equivalent MongoDB collection in `optimade`:
 [`MongoCollection`](https://www.optimade.org/optimade-python-tools/api_reference/server/entry_collections/mongo/#optimade.server.entry_collections.mongo.MongoCollection).
 """
+from __future__ import annotations
+
 from datetime import datetime
 from os import getenv
 from typing import TYPE_CHECKING
@@ -22,7 +24,7 @@ from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    from typing import Any, Dict, List, Optional, Set, Tuple, Union
+    from typing import Any
 
     from optimade.models import EntryResource
     from optimade.server.mappers.entries import BaseResourceMapper
@@ -44,8 +46,8 @@ class AsyncMongoCollection(EntryCollection):
     def __init__(
         self,
         name: str,
-        resource_cls: "EntryResource",
-        resource_mapper: "BaseResourceMapper",
+        resource_cls: EntryResource,
+        resource_mapper: BaseResourceMapper,
     ):
         """Initialize the AsyncMongoCollection for the given parameters.
 
@@ -100,14 +102,14 @@ class AsyncMongoCollection(EntryCollection):
         )
         return 0
 
-    def insert(self, data: "List[EntryResource]") -> None:
+    def insert(self, data: list[EntryResource]) -> None:
         raise NotImplementedError(
             "This method cannot be used with this class and is a remnant from the "
             "parent class. Use instead the asynchronous method `ainsert(data: "
             "List[EntryResource])`."
         )
 
-    async def ainsert(self, data: "List[EntryResource]") -> None:
+    async def ainsert(self, data: list[EntryResource]) -> None:
         """Add the given entries to the underlying database.
 
         This is the asynchronous version of the parent class method named `insert()`.
@@ -128,8 +130,8 @@ class AsyncMongoCollection(EntryCollection):
 
     async def acount(
         self,
-        params: "Optional[Union[EntryListingQueryParams, SingleEntryQueryParams]]" = None,  # noqa: E501
-        **kwargs: "Any",
+        params: None | (EntryListingQueryParams | SingleEntryQueryParams) = None,
+        **kwargs: Any,
     ) -> int:
         """Count documents in Collection.
 
@@ -173,8 +175,10 @@ class AsyncMongoCollection(EntryCollection):
         return await self.collection.count_documents(**criteria)
 
     def find(
-        self, params: "Union[EntryListingQueryParams, SingleEntryQueryParams]"
-    ) -> "Tuple[Union[List[EntryResource], EntryResource, None], int, bool, Set[str], Set[str]]":  # noqa: E501
+        self, params: EntryListingQueryParams | SingleEntryQueryParams
+    ) -> tuple[
+        list[EntryResource] | EntryResource | None, int, bool, set[str], set[str]
+    ]:
         """
         Fetches results and indicates if more data is available.
 
@@ -201,9 +205,11 @@ class AsyncMongoCollection(EntryCollection):
 
     async def afind(
         self,
-        params: "Optional[Union[EntryListingQueryParams, SingleEntryQueryParams]]" = None,  # noqa: E501
-        criteria: "Optional[Dict[str, Any]]" = None,
-    ) -> "Tuple[Union[List[EntryResource], EntryResource, None], int, bool, Set[str], Set[str]]":  # noqa: E501
+        params: None | (EntryListingQueryParams | SingleEntryQueryParams) = None,
+        criteria: dict[str, Any] | None = None,
+    ) -> tuple[
+        list[EntryResource] | EntryResource | None, int, bool, set[str], set[str]
+    ]:
         """Perform the query on the underlying MongoDB Collection, handling projection
         and pagination of the output.
 
@@ -300,8 +306,8 @@ class AsyncMongoCollection(EntryCollection):
         )
 
     def handle_query_params(
-        self, params: "Union[EntryListingQueryParams, SingleEntryQueryParams]"
-    ) -> "Dict[str, Any]":
+        self, params: EntryListingQueryParams | SingleEntryQueryParams
+    ) -> dict[str, Any]:
         """Parse and interpret the backend-agnostic query parameter models into a
         dictionary that can be used by the specific backend.
 
@@ -329,8 +335,8 @@ class AsyncMongoCollection(EntryCollection):
         )
 
     async def ahandle_query_params(
-        self, params: "Union[EntryListingQueryParams, SingleEntryQueryParams]"
-    ) -> "Dict[str, Any]":
+        self, params: EntryListingQueryParams | SingleEntryQueryParams
+    ) -> dict[str, Any]:
         """Parse and interpret the backend-agnostic query parameter models into a
         dictionary that can be used by the specific backend.
 
@@ -356,8 +362,8 @@ class AsyncMongoCollection(EntryCollection):
         return super().handle_query_params(params)
 
     def _run_db_query(
-        self, criteria: "Dict[str, Any]", single_entry: bool = False
-    ) -> "Tuple[List[Dict[str, Any]], int, bool]":
+        self, criteria: dict[str, Any], single_entry: bool = False
+    ) -> tuple[list[dict[str, Any]], int, bool]:
         raise NotImplementedError(
             "This method cannot be used with this class and is a remnant from the "
             "parent class. Use instead the asynchronous method "
@@ -365,8 +371,8 @@ class AsyncMongoCollection(EntryCollection):
         )
 
     async def _arun_db_query(
-        self, criteria: "Dict[str, Any]", single_entry: bool = False
-    ) -> "Tuple[List[Dict[str, Any]], int, bool]":
+        self, criteria: dict[str, Any], single_entry: bool = False
+    ) -> tuple[list[dict[str, Any]], int, bool]:
         """Run the query on the backend and collect the results.
 
         This is the asynchronous version of the parent class method named `count()`.
@@ -400,7 +406,7 @@ class AsyncMongoCollection(EntryCollection):
         return results, data_returned, more_data_available
 
     @staticmethod
-    def _check_aliases(aliases: "Tuple[Tuple[str, str]]") -> None:
+    def _check_aliases(aliases: tuple[tuple[str, str]]) -> None:
         """Check that aliases do not clash with mongo keywords.
 
         Parameters:
@@ -415,7 +421,7 @@ class AsyncMongoCollection(EntryCollection):
         ):
             raise RuntimeError(f"Cannot define an alias starting with a '$': {aliases}")
 
-    async def get_one(self, **criteria: "Any") -> "EntryResource":
+    async def get_one(self, **criteria: Any) -> EntryResource:
         """Get one resource based on criteria
 
         Warning:
@@ -437,7 +443,7 @@ class AsyncMongoCollection(EntryCollection):
             )
         )
 
-    async def get_multiple(self, **criteria: "Any") -> "List[EntryResource]":
+    async def get_multiple(self, **criteria: Any) -> list[EntryResource]:
         """Get a list of resources based on criteria
 
         Warning:
@@ -459,7 +465,7 @@ class AsyncMongoCollection(EntryCollection):
 
         return results
 
-    async def create_one(self, resource: "EntryResourceCreate") -> "EntryResource":
+    async def create_one(self, resource: EntryResourceCreate) -> EntryResource:
         """Create a new document in the MongoDB collection based on query parameters.
 
         Update the newly created document with an `"id"` field.
@@ -506,7 +512,7 @@ class AsyncMongoCollection(EntryCollection):
         return bool(await self.collection.count_documents({"id": entry_id}))
 
     @staticmethod
-    def _valid_find_keys(**kwargs: "Dict[str, Any]") -> "Dict[str, Any]":
+    def _valid_find_keys(**kwargs: dict[str, Any]) -> dict[str, Any]:
         """Return valid MongoDB find() keys with values from kwargs
 
         Note, not including deprecated flags

--- a/optimade_gateway/mongo/database.py
+++ b/optimade_gateway/mongo/database.py
@@ -1,4 +1,6 @@
 """Initialize the MongoDB database."""
+from __future__ import annotations
+
 from os import getenv
 from typing import TYPE_CHECKING
 
@@ -12,7 +14,7 @@ if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from pymongo.mongo_client import MongoClient
 
 
-MONGO_CLIENT: "MongoClient" = AsyncIOMotorClient(
+MONGO_CLIENT: MongoClient = AsyncIOMotorClient(
     CONFIG.mongo_uri,
     appname="optimade-gateway",
     readConcernLevel="majority",
@@ -21,7 +23,7 @@ MONGO_CLIENT: "MongoClient" = AsyncIOMotorClient(
 )
 """The MongoDB motor client."""
 
-MONGO_DB: "Database" = MONGO_CLIENT[CONFIG.mongo_database]
+MONGO_DB: Database = MONGO_CLIENT[CONFIG.mongo_database]
 """The MongoDB motor database.
 This is a representation of the database used for the gateway service."""
 

--- a/optimade_gateway/queries/params.py
+++ b/optimade_gateway/queries/params.py
@@ -1,5 +1,7 @@
 """URL query parameters."""
-from typing import Set
+from __future__ import annotations
+
+from typing import Annotated
 
 from fastapi import Query
 from pydantic import AnyUrl
@@ -10,7 +12,7 @@ class SearchQueryParams:
 
     This is an extension of the
     [`EntryListingQueryParams`](https://www.optimade.org/optimade-python-tools/api_reference/server/query_params/#optimade.server.query_params.EntryListingQueryParams)
-    class in `optimade´, which defines the standard entry listing endpoint query
+    class in `optimade`, which defines the standard entry listing endpoint query
     parameters.
 
     The extra query parameters are as follows.
@@ -49,50 +51,60 @@ class SearchQueryParams:
     def __init__(
         self,
         *,
-        database_ids: Set[str] = Query(
-            set(),
-            description=(
-                "Unique list of possible database IDs that are already known by the "
-                "gateway. To be known they need to be registered with the gateway "
-                "(currently not possible)."
+        database_ids: Annotated[
+            set[str],
+            Query(
+                description=(
+                    "Unique list of possible database IDs that are already known by "
+                    "the gateway. To be known they need to be registered with the "
+                    "gateway (currently not possible)."
+                ),
             ),
-        ),
-        optimade_urls: Set[AnyUrl] = Query(
-            set(),
-            description=(
-                "A unique list of OPTIMADE base URLs. If a versioned base URL is "
-                "supplied it will be used as is, as long as it represents a supported "
-                "version. If an un-versioned base URL, standard version negotiation "
-                "will be conducted to get the versioned base URL, which will be used "
-                "as long as it represents a supported version."
+        ] = set(),
+        optimade_urls: Annotated[
+            set[AnyUrl],
+            Query(
+                description=(
+                    "A unique list of OPTIMADE base URLs. If a versioned base URL is "
+                    "supplied it will be used as is, as long as it represents a "
+                    "supported version. If an un-versioned base URL, standard version "
+                    "negotiation will be conducted to get the versioned base URL, "
+                    "which will be used as long as it represents a supported version."
+                ),
             ),
-        ),
-        endpoint: str = Query(
-            "structures",
-            description=(
-                "The entry endpoint queried. According to the OPTIMADE specification, "
-                "this is the same as the resource's type."
+        ] = set(),
+        endpoint: Annotated[
+            str,
+            Query(
+                description=(
+                    "The entry endpoint queried. According to the OPTIMADE "
+                    "specification, this is the same as the resource's type."
+                ),
             ),
-        ),
-        timeout: int = Query(
-            15,
-            description=(
-                "Timeout time (in seconds) to wait for a query to finish before "
-                "redirecting (*after* starting the query). Note, if the query has not "
-                "finished after the timeout time, a redirection will still be "
-                "performed, but to a zero-results page, which can be refreshed to get "
-                "the finished query (once it has finished)."
+        ] = "structures",
+        timeout: Annotated[
+            int,
+            Query(
+                description=(
+                    "Timeout time (in seconds) to wait for a query to finish before "
+                    "redirecting (*after* starting the query). Note, if the query has "
+                    "not finished after the timeout time, a redirection will still be "
+                    "performed, but to a zero-results page, which can be refreshed to "
+                    "get the finished query (once it has finished)."
+                ),
             ),
-        ),
-        as_optimade: bool = Query(
-            False,
-            description=(
-                "Return the response as a standard OPTIMADE entry listing endpoint "
-                "response. Otherwise, the response will be based on the "
-                "[`QueriesResponseSingle`][optimade_gateway.models.responses.QueriesResponseSingle]"
-                " model."
+        ] = 15,
+        as_optimade: Annotated[
+            bool,
+            Query(
+                description=(
+                    "Return the response as a standard OPTIMADE entry listing endpoint "
+                    "response. Otherwise, the response will be based on the "
+                    "[`QueriesResponseSingle`][optimade_gateway.models.responses.QueriesResponseSingle]"
+                    " model."
+                ),
             ),
-        ),
+        ] = False,
     ) -> None:
         self.database_ids = database_ids
         self.optimade_urls = optimade_urls

--- a/optimade_gateway/queries/params.py
+++ b/optimade_gateway/queries/params.py
@@ -1,6 +1,4 @@
 """URL query parameters."""
-from __future__ import annotations
-
 from typing import Annotated
 
 from fastapi import Query
@@ -18,11 +16,11 @@ class SearchQueryParams:
     The extra query parameters are as follows.
 
     Attributes:
-        database_ids (Set[str]): List of possible database IDs that are already known by
+        database_ids (set[str]): List of possible database IDs that are already known by
             the gateway. To be known they need to be registered with the gateway
             (currently not possible).
 
-        optimade_urls (Set[AnyUrl]): A list of OPTIMADE base URLs. If a versioned base
+        optimade_urls (set[AnyUrl]): A list of OPTIMADE base URLs. If a versioned base
             URL is supplied it will be used as is, as long as it represents a supported
             version. If an un-versioned base URL, standard version negotiation will be
             conducted to get the versioned base URL, which will be used as long as it

--- a/optimade_gateway/queries/perform.py
+++ b/optimade_gateway/queries/perform.py
@@ -12,7 +12,7 @@ import httpx
 from optimade import __api_version__
 from optimade.models import ErrorResponse, ToplevelLinks
 from optimade.server.routers.utils import BASE_URL_PREFIXES, meta_values
-from pydantic import ValidationError, AnyUrl
+from pydantic import AnyUrl, ValidationError
 
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
@@ -183,7 +183,9 @@ def db_find(
     else:
         url = ""
 
-        base_url = str(get_resource_attribute(database, "attributes.base_url")).rstrip("/")
+        base_url = str(get_resource_attribute(database, "attributes.base_url")).rstrip(
+            "/"
+        )
         url += base_url
 
         # Check whether base_url is a versioned base URL

--- a/optimade_gateway/queries/perform.py
+++ b/optimade_gateway/queries/perform.py
@@ -317,7 +317,7 @@ async def db_get_all_resources(
         LOGGER.error(
             "Error while querying database (id=%r). Full response: %s",
             get_resource_attribute(database, "id"),
-            response.json(indent=2),
+            response.model_dump_json(indent=2),
         )
         return [], database
 

--- a/optimade_gateway/queries/perform.py
+++ b/optimade_gateway/queries/perform.py
@@ -1,4 +1,6 @@
 """Perform OPTIMADE queries"""
+from __future__ import annotations
+
 import asyncio
 import functools
 import json
@@ -21,9 +23,8 @@ from optimade_gateway.queries.process import process_db_response
 from optimade_gateway.queries.utils import update_query
 from optimade_gateway.routers.utils import collection_factory, get_valid_resource
 
-
 if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    from typing import Any, Dict, List, Optional, Tuple, Union
+    from typing import Any
 
     from optimade.models import (
         EntryResource,
@@ -37,9 +38,9 @@ if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
 
 
 async def perform_query(
-    url: "URL",
-    query: "QueryResource",
-) -> "Union[EntryResponseMany, ErrorResponse, GatewayQueryResponse]":
+    url: URL,
+    query: QueryResource,
+) -> EntryResponseMany | ErrorResponse | GatewayQueryResponse:
     """Perform OPTIMADE query with gateway.
 
     Parameters:
@@ -146,12 +147,12 @@ async def perform_query(
 
 
 def db_find(
-    database: "Union[LinksResource, Dict[str, Any]]",
+    database: LinksResource | dict[str, Any],
     endpoint: str,
-    response_model: "Union[EntryResponseMany, EntryResponseOne]",
+    response_model: EntryResponseMany | EntryResponseOne,
     query_params: str = "",
-    raw_url: "Optional[str]" = None,
-) -> "Tuple[Union[ErrorResponse, EntryResponseMany, EntryResponseOne], str]":
+    raw_url: str | None = None,
+) -> tuple[ErrorResponse | EntryResponseMany | EntryResponseOne, str]:
     """Imitate `Collection.find()` for any given database for entry-resource endpoints
 
     Parameters:
@@ -169,7 +170,13 @@ def db_find(
 
     """
     if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-        response: "Union[httpx.Response, Dict[str, Any], EntryResponseMany, EntryResponseOne, ErrorResponse]"  # noqa: E501
+        response: (
+            httpx.Response
+            | dict[str, Any]
+            | EntryResponseMany
+            | EntryResponseOne
+            | ErrorResponse
+        )
 
     if raw_url:
         url = raw_url
@@ -266,12 +273,12 @@ def db_find(
 
 
 async def db_get_all_resources(
-    database: "Union[LinksResource, Dict[str, Any]]",
+    database: LinksResource | dict[str, Any],
     endpoint: str,
-    response_model: "EntryResponseMany",
+    response_model: EntryResponseMany,
     query_params: str = "",
-    raw_url: "Optional[str]" = None,
-) -> "Tuple[List[Union[EntryResource, Dict[str, Any]]], Union[LinksResource, Dict[str, Any]]]":  # noqa: E501
+    raw_url: str | None = None,
+) -> tuple[list[EntryResource | dict[str, Any]], LinksResource | dict[str, Any]]:
     """Recursively retrieve all resources from an entry-listing endpoint
 
     This function keeps pulling the `links.next` link if `meta.more_data_available` is

--- a/optimade_gateway/queries/prepare.py
+++ b/optimade_gateway/queries/prepare.py
@@ -1,4 +1,6 @@
 """Prepare OPTIMADE queries."""
+from __future__ import annotations
+
 import re
 import urllib.parse
 from os import getenv
@@ -9,14 +11,13 @@ from optimade_gateway.warnings import OptimadeGatewayWarning
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from collections.abc import Mapping
-    from typing import List, Union
 
     from optimade_gateway.models.queries import OptimadeQueryParameters
 
 
 async def prepare_query_filter(
-    database_ids: "List[str]", filter_query: "Union[str, None]"
-) -> "Mapping[str, Union[str, None]]":
+    database_ids: list[str], filter_query: str | None
+) -> Mapping[str, str | None]:
     """Update the query parameter `filter` value to be database-specific
 
     This is needed due to the served change of `id` values.
@@ -71,9 +72,9 @@ async def prepare_query_filter(
 
 
 async def get_query_params(
-    query_parameters: "OptimadeQueryParameters",
+    query_parameters: OptimadeQueryParameters,
     database_id: str,
-    filter_mapping: "Mapping[str, Union[str, None]]",
+    filter_mapping: Mapping[str, str | None],
 ) -> str:
     """Construct the parsed URL query parameters"""
     query_params = {

--- a/optimade_gateway/queries/prepare.py
+++ b/optimade_gateway/queries/prepare.py
@@ -8,13 +8,7 @@ from warnings import warn
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Mapping
-    else:
-        from typing import Mapping
-
+    from collections.abc import Mapping
     from typing import List, Union
 
     from optimade_gateway.models.queries import OptimadeQueryParameters

--- a/optimade_gateway/queries/process.py
+++ b/optimade_gateway/queries/process.py
@@ -63,7 +63,7 @@ async def process_db_response(
                 # model.
                 meta_error = {}
                 if error.meta:
-                    meta_error = error.meta.dict()
+                    meta_error = error.meta.model_dump()
                 meta_error.update(
                     {
                         f"_{CONFIG.provider.prefix}_source_gateway": {

--- a/optimade_gateway/queries/process.py
+++ b/optimade_gateway/queries/process.py
@@ -1,4 +1,6 @@
 """Process performed OPTIMADE queries."""
+from __future__ import annotations
+
 from os import getenv
 from typing import TYPE_CHECKING
 from warnings import warn
@@ -12,7 +14,7 @@ from optimade_gateway.queries.utils import update_query
 from optimade_gateway.warnings import OptimadeGatewayWarning
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    from typing import Any, Dict, List, Union
+    from typing import Any
 
     from optimade.models import EntryResource, EntryResponseMany, EntryResponseOne
 
@@ -20,11 +22,13 @@ if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
 
 
 async def process_db_response(
-    response: "Union[ErrorResponse, EntryResponseMany, EntryResponseOne]",
+    response: ErrorResponse | EntryResponseMany | EntryResponseOne,
     database_id: str,
-    query: "QueryResource",
-    gateway: "GatewayResource",
-) -> "Union[List[EntryResource], List[Dict[str, Any]], EntryResource, Dict[str, Any], None]":  # noqa: E501
+    query: QueryResource,
+    gateway: GatewayResource,
+) -> (
+    list[EntryResource] | list[dict[str, Any]] | EntryResource | dict[str, Any] | None
+):
     """Process an OPTIMADE database response.
 
     The passed `query` will be updated with the top-level `meta` information:

--- a/optimade_gateway/queries/utils.py
+++ b/optimade_gateway/queries/utils.py
@@ -1,4 +1,6 @@
 """Utility functions for the `queries` module."""
+from __future__ import annotations
+
 from datetime import datetime
 from os import getenv
 from typing import TYPE_CHECKING
@@ -9,7 +11,7 @@ from optimade_gateway.common.utils import clean_python_types
 from optimade_gateway.routers.utils import collection_factory
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    from typing import Any, Dict, Optional, Union
+    from typing import Any
 
     from pydantic import BaseModel
     from pymongo.results import UpdateResult
@@ -18,11 +20,11 @@ if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
 
 
 async def update_query(
-    query: "QueryResource",
+    query: QueryResource,
     field: str,
-    value: "Any",
-    operator: "Optional[str]" = None,
-    **mongo_kwargs: "Any",
+    value: Any,
+    operator: str | None = None,
+    **mongo_kwargs: Any,
 ) -> None:
     """Update a query's `field` attribute with `value`.
 
@@ -69,7 +71,7 @@ async def update_query(
 
     # MongoDB
     collection = await collection_factory(CONFIG.queries_collection)
-    result: "UpdateResult" = await collection.collection.update_one(
+    result: UpdateResult = await collection.collection.update_one(
         filter={"id": {"$eq": query.id}},
         update=await clean_python_types(update_kwargs),
     )
@@ -87,9 +89,7 @@ async def update_query(
     query.attributes.last_modified = update_time
     if "." in field:
         field_list = field.split(".")
-        sub_field: "Union[BaseModel, Dict[str, Any]]" = getattr(
-            query.attributes, field_list[0]
-        )
+        sub_field: BaseModel | dict[str, Any] = getattr(query.attributes, field_list[0])
         for field_part in field_list[1:-1]:
             if isinstance(sub_field, dict):
                 sub_field = sub_field.get(field_part, {})

--- a/optimade_gateway/queries/utils.py
+++ b/optimade_gateway/queries/utils.py
@@ -1,7 +1,7 @@
 """Utility functions for the `queries` module."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from os import getenv
 from typing import TYPE_CHECKING
 
@@ -54,7 +54,7 @@ async def update_query(
     if operator and not operator.startswith("$"):
         operator = f"${operator}"
 
-    update_time = datetime.utcnow()
+    update_time = datetime.now(timezone.utc)
 
     update_kwargs = {"$set": {"last_modified": update_time}}
 

--- a/optimade_gateway/routers/databases.py
+++ b/optimade_gateway/routers/databases.py
@@ -11,6 +11,10 @@ Database resources represent the available databases that may be used for the ga
 One can register a new database (by using `POST /databases`) or look through the
 available databases (by using `GET /databases`) using standard OPTIMADE filtering.
 """
+from __future__ import annotations
+
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Request
 from optimade.models import ToplevelLinks
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
@@ -43,7 +47,7 @@ ROUTER = APIRouter(redirect_slashes=True)
 )
 async def get_databases(
     request: Request,
-    params: EntryListingQueryParams = Depends(),
+    params: Annotated[EntryListingQueryParams, Depends()],
 ) -> DatabasesResponse:
     """`GET /databases`
 
@@ -104,7 +108,7 @@ async def post_databases(
 async def get_database(
     request: Request,
     database_id: str,
-    params: SingleEntryQueryParams = Depends(),
+    params: Annotated[SingleEntryQueryParams, Depends()],
 ) -> DatabasesResponseSingle:
     """`GET /databases/{database ID}`
 

--- a/optimade_gateway/routers/gateways.py
+++ b/optimade_gateway/routers/gateways.py
@@ -6,6 +6,10 @@ This file describes the router for:
 
 where, `id` may be left out.
 """
+from __future__ import annotations
+
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Request
 from optimade.models import ToplevelLinks
 from optimade.server.query_params import EntryListingQueryParams
@@ -40,7 +44,7 @@ ROUTER = APIRouter(redirect_slashes=True)
 )
 async def get_gateways(
     request: Request,
-    params: EntryListingQueryParams = Depends(),
+    params: Annotated[EntryListingQueryParams, Depends()],
 ) -> GatewaysResponse:
     """`GET /gateways`
 
@@ -82,7 +86,7 @@ async def post_gateways(
 
         current_database_ids = [_.id for _ in gateway.databases]
         gateway.databases.extend(
-            (_ for _ in databases if _.id not in current_database_ids)
+            _ for _ in databases if _.id not in current_database_ids
         )
 
     result, created = await resource_factory(gateway)

--- a/optimade_gateway/routers/info.py
+++ b/optimade_gateway/routers/info.py
@@ -6,6 +6,8 @@ This file describes the router for:
 
 where, `entry` may be left out.
 """
+from __future__ import annotations
+
 from fastapi import APIRouter, Request
 from optimade import __api_version__
 from optimade.models import (
@@ -72,8 +74,8 @@ async def get_info(request: Request) -> InfoResponse:
                         "openapi.json",
                         "redoc",
                         "search",
+                        *list(ENTRY_INFO_SCHEMAS.keys()),
                     ]
-                    + list(ENTRY_INFO_SCHEMAS.keys())
                 ),
                 is_index=False,
             ),

--- a/optimade_gateway/routers/info.py
+++ b/optimade_gateway/routers/info.py
@@ -15,6 +15,7 @@ from optimade.models import (
     BaseInfoResource,
     EntryInfoResource,
     EntryInfoResponse,
+    EntryResource,
     InfoResponse,
     LinksResource,
 )
@@ -28,11 +29,12 @@ from optimade_gateway.routers.utils import aretrieve_queryable_properties
 
 ROUTER = APIRouter(redirect_slashes=True)
 
-ENTRY_INFO_SCHEMAS = {
-    "databases": LinksResource.schema,
-    "gateways": GatewayResource.schema,
-    "queries": QueryResource.schema,
+ENTRY_INFO_SCHEMAS: dict[str, type[EntryResource]] = {
+    "databases": LinksResource,
+    "gateways": GatewayResource,
+    "queries": QueryResource,
 }
+"""This dictionary is used to define the `/info/<entry_type>` endpoints."""
 
 
 @ROUTER.get(
@@ -51,8 +53,8 @@ async def get_info(request: Request) -> InfoResponse:
     """
     return InfoResponse(
         data=BaseInfoResource(
-            id=BaseInfoResource.schema()["properties"]["id"]["default"],
-            type=BaseInfoResource.schema()["properties"]["type"]["default"],
+            id=BaseInfoResource.model_fields["id"].default,
+            type=BaseInfoResource.model_fields["type"].default,
             attributes=BaseInfoAttributes(
                 api_version=__api_version__,
                 available_api_versions=[
@@ -113,16 +115,16 @@ async def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
             ),
         )
 
-    schema = ENTRY_INFO_SCHEMAS[entry]()
+    schema = ENTRY_INFO_SCHEMAS[entry]
     queryable_properties = {"id", "type", "attributes"}
-    properties = await aretrieve_queryable_properties(schema, queryable_properties)
+    properties = await aretrieve_queryable_properties(schema, queryable_properties, entry_type=entry)
 
-    output_fields_by_format = {"json": list(properties.keys())}
+    output_fields_by_format = {"json": list(properties)}
 
     return EntryInfoResponse(
         data=EntryInfoResource(
-            formats=list(output_fields_by_format.keys()),
-            description=schema.get("description", "Entry Resources"),
+            formats=list(output_fields_by_format),
+            description=getattr(schema, "__doc__", "Entry Resources"),
             properties=properties,
             output_fields_by_format=output_fields_by_format,
         ),

--- a/optimade_gateway/routers/info.py
+++ b/optimade_gateway/routers/info.py
@@ -117,7 +117,9 @@ async def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
 
     schema = ENTRY_INFO_SCHEMAS[entry]
     queryable_properties = {"id", "type", "attributes"}
-    properties = await aretrieve_queryable_properties(schema, queryable_properties, entry_type=entry)
+    properties = await aretrieve_queryable_properties(
+        schema, queryable_properties, entry_type=entry
+    )
 
     output_fields_by_format = {"json": list(properties)}
 

--- a/optimade_gateway/routers/links.py
+++ b/optimade_gateway/routers/links.py
@@ -5,6 +5,10 @@ This file describes the router for:
     /links
 
 """
+from __future__ import annotations
+
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Request
 from optimade.models import LinksResponse
 from optimade.server.query_params import EntryListingQueryParams
@@ -26,7 +30,7 @@ ROUTER = APIRouter(redirect_slashes=True)
     responses=ERROR_RESPONSES,
 )
 async def get_links(
-    request: Request, params: EntryListingQueryParams = Depends()
+    request: Request, params: Annotated[EntryListingQueryParams, Depends()]
 ) -> LinksResponse:
     """`GET /links`
 

--- a/optimade_gateway/routers/search.py
+++ b/optimade_gateway/routers/search.py
@@ -237,7 +237,7 @@ async def get_search(
             query_parameters=OptimadeQueryParameters(
                 **{
                     field: getattr(entry_params, field)
-                    for field in OptimadeQueryParameters.__fields__
+                    for field in OptimadeQueryParameters.model_fields
                     if getattr(entry_params, field)
                 }
             ),

--- a/optimade_gateway/routers/search.py
+++ b/optimade_gateway/routers/search.py
@@ -119,10 +119,15 @@ async def post_search(request: Request, search: Search) -> QueriesResponseSingle
         databases.extend(
             [
                 LinksResource(
-                    id=str(url).replace(".", "__")[len(url.scheme) + 3 :].split("?", maxsplit=1)[0].split("#", maxsplit=1)[0],
+                    id=str(url)
+                    .replace(".", "__")[len(url.scheme) + 3 :]
+                    .split("?", maxsplit=1)[0]
+                    .split("#", maxsplit=1)[0],
                     type="links",
                     attributes=LinksResourceAttributes(
-                        name=str(url)[len(url.scheme) + 3 :].split("?", maxsplit=1)[0].split("#", maxsplit=1)[0],
+                        name=str(url)[len(url.scheme) + 3 :]
+                        .split("?", maxsplit=1)[0]
+                        .split("#", maxsplit=1)[0],
                         description="",
                         base_url=url,
                         link_type=LinkType.CHILD,

--- a/optimade_gateway/routers/search.py
+++ b/optimade_gateway/routers/search.py
@@ -15,7 +15,15 @@ from fastapi import APIRouter, Depends, Request, Response, status
 from fastapi.responses import RedirectResponse
 from optimade.models import LinksResource, LinksResourceAttributes, ToplevelLinks
 from optimade.models.links import LinkType
-from optimade.models.responses import EntryResponseMany, ErrorResponse
+from optimade.models.responses import (
+    EntryResponseMany as OptimadeEntryResponseMany,
+)
+from optimade.models.responses import (
+    ErrorResponse,
+    LinksResponse,
+    ReferenceResponseMany,
+    StructureResponseMany,
+)
 from optimade.server.exceptions import BadRequest, InternalServerError
 from optimade.server.query_params import EntryListingQueryParams
 from optimade.server.routers.utils import meta_values
@@ -38,6 +46,13 @@ from optimade_gateway.queries.perform import perform_query
 from optimade_gateway.routers.utils import collection_factory, resource_factory
 
 ROUTER = APIRouter(redirect_slashes=True)
+
+EntryResponseMany = Union[
+    StructureResponseMany,
+    ReferenceResponseMany,
+    LinksResponse,
+    OptimadeEntryResponseMany,
+]
 
 
 @ROUTER.post(
@@ -193,7 +208,7 @@ async def post_search(request: Request, search: Search) -> QueriesResponseSingle
 
 @ROUTER.get(
     "/search",
-    response_model=Union[QueriesResponseSingle, EntryResponseMany, ErrorResponse],
+    response_model=Union[QueriesResponseSingle, ErrorResponse, EntryResponseMany],
     response_model_exclude_defaults=False,
     response_model_exclude_none=False,
     response_model_exclude_unset=True,

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -103,6 +103,7 @@ async def aretrieve_queryable_properties(
     Parameters:
         schema: The schema of the pydantic model.
         queryable_properties: The list of properties to find in the schema.
+        entry_type: The entry type of the model, if any.
 
     Returns:
         A flat dictionary with properties as keys, containing the field description,
@@ -194,12 +195,12 @@ async def resource_factory(
     Returns:
         Two things in a tuple:
 
-        - Either a
-            [`GatewayResource`][optimade_gateway.models.gateways.GatewayResource];
-            a [`QueryResource`][optimade_gateway.models.queries.QueryResource]; or a
-            [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource)
-            and
-        - whether or not the resource was newly created.
+            - Either a
+                [`GatewayResource`][optimade_gateway.models.gateways.GatewayResource];
+                a [`QueryResource`][optimade_gateway.models.queries.QueryResource]; or a
+                [`LinksResource`](https://www.optimade.org/optimade-python-tools/api_reference/models/links/#optimade.models.links.LinksResource)
+                and
+            - whether or not the resource was newly created.
 
     """
     created = False

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -26,13 +26,7 @@ from optimade_gateway.models import (
 from optimade_gateway.mongo.collection import AsyncMongoCollection
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Iterable
-    else:
-        from typing import Iterable
-
+    from collections.abc import Iterable
     from typing import Any, Dict, Tuple, Union
 
     from fastapi import Request

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -1,4 +1,6 @@
 """Utility functions for all routers."""
+from __future__ import annotations
+
 import urllib.parse
 from os import getenv
 from typing import TYPE_CHECKING
@@ -27,7 +29,7 @@ from optimade_gateway.mongo.collection import AsyncMongoCollection
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from collections.abc import Iterable
-    from typing import Any, Dict, Tuple, Union
+    from typing import Any
 
     from fastapi import Request
     from optimade.models import EntryResource, EntryResponseMany, LinksResource
@@ -36,16 +38,16 @@ if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from optimade_gateway.models import GatewayResource, QueryResource
 
 
-COLLECTIONS: "Dict[str, AsyncMongoCollection]" = {}
+COLLECTIONS: dict[str, AsyncMongoCollection] = {}
 """A lazy-loaded dictionary of asynchronous MongoDB entry-endpoint collections."""
 
 
 async def get_entries(
     collection: AsyncMongoCollection,
-    response_cls: "EntryResponseMany",
-    request: "Request",
-    params: "EntryListingQueryParams",
-) -> "EntryResponseMany":
+    response_cls: EntryResponseMany,
+    request: Request,
+    params: EntryListingQueryParams,
+) -> EntryResponseMany:
     """Generalized `/{entries}` endpoint getter"""
     (
         results,
@@ -83,7 +85,7 @@ async def get_entries(
 
 
 async def aretrieve_queryable_properties(
-    schema: "Dict[str, Any]", queryable_properties: "Iterable"
+    schema: dict[str, Any], queryable_properties: Iterable
 ) -> dict:
     """Asynchronous implementation of `retrieve_queryable_properties()` from `optimade`
 
@@ -119,15 +121,15 @@ async def validate_resource(collection: AsyncMongoCollection, entry_id: str) -> 
 
 async def get_valid_resource(
     collection: AsyncMongoCollection, entry_id: str
-) -> "EntryResource":
+) -> EntryResource:
     """Validate and retrieve a resource"""
     await validate_resource(collection, entry_id)
     return await collection.get_one(filter={"id": entry_id})
 
 
 async def resource_factory(
-    create_resource: "Union[DatabaseCreate, GatewayCreate, QueryCreate]",
-) -> "Tuple[Union[LinksResource, GatewayResource, QueryResource], bool]":
+    create_resource: DatabaseCreate | GatewayCreate | QueryCreate,
+) -> tuple[LinksResource | GatewayResource | QueryResource, bool]:
     """Get or create a resource
 
     Currently supported resources:

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -29,7 +29,6 @@ from optimade_gateway.mongo.collection import AsyncMongoCollection
 
 if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from collections.abc import Iterable
-    from typing import Any
 
     from fastapi import Request
     from optimade.models import EntryResource, EntryResponseMany, LinksResource
@@ -86,8 +85,10 @@ async def get_entries(
 
 
 async def aretrieve_queryable_properties(
-    schema: type[EntryResource], queryable_properties: Iterable[str], entry_type: str | None = None
-) -> "QueryableProperties":
+    schema: type[EntryResource],
+    queryable_properties: Iterable[str],
+    entry_type: str | None = None,
+) -> QueryableProperties:
     """Asynchronous implementation of `retrieve_queryable_properties()` from `optimade`
 
     Reference to the function in the `optimade` API documentation:

--- a/optimade_gateway/routers/utils.py
+++ b/optimade_gateway/routers/utils.py
@@ -285,9 +285,9 @@ async def resource_factory(
                 create_resource.homepage = None
         elif isinstance(create_resource, GatewayCreate):
             # Do not store `database_ids`
-            if "database_ids" in create_resource.__fields_set__:
+            if "database_ids" in create_resource.model_fields_set:
                 create_resource.database_ids = None
-                create_resource.__fields_set__.remove("database_ids")
+                create_resource.model_fields_set.remove("database_ids")
         elif isinstance(create_resource, QueryCreate):
             create_resource.state = QueryState.CREATED
         result = await collection.create_one(create_resource)

--- a/optimade_gateway/run.py
+++ b/optimade_gateway/run.py
@@ -1,4 +1,6 @@
 """Simplified function for running the server used in the CLI."""
+from __future__ import annotations
+
 import argparse
 import os
 from pathlib import Path
@@ -8,10 +10,9 @@ import uvicorn
 
 if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
     from collections.abc import Sequence
-    from typing import Optional
 
 
-def run(argv: "Optional[Sequence[str]]" = None) -> None:
+def run(argv: Sequence[str] | None = None) -> None:
     """Run OPTIMADE Gateway REST API server."""
     parser = argparse.ArgumentParser(
         "optimade-gateway",
@@ -37,7 +38,7 @@ def run(argv: "Optional[Sequence[str]]" = None) -> None:
         "log_level": "debug",
     }
 
-    os.environ["optimade_load_optimade_providers_databases"] = (
+    os.environ["OPTIMADE_LOAD_OPTIMADE_PROVIDERS_DATABASES"] = (
         "True" if args.load_providers else "False"
     )
 

--- a/optimade_gateway/run.py
+++ b/optimade_gateway/run.py
@@ -7,13 +7,7 @@ from typing import TYPE_CHECKING
 import uvicorn
 
 if TYPE_CHECKING or bool(os.getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Sequence
-    else:
-        from typing import Sequence
-
+    from collections.abc import Sequence
     from typing import Optional
 
 

--- a/optimade_gateway/warnings.py
+++ b/optimade_gateway/warnings.py
@@ -3,6 +3,8 @@
 The warnings in this module will all be caught by middleware and added to the response
 under `meta.warnings`.
 """
+from __future__ import annotations
+
 from optimade.server.warnings import OptimadeWarning
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,9 @@ license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Intended Audience :: Developers",
     "Topic :: Database",
     "Topic :: Database :: Database Engines/Servers",
@@ -23,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 keywords = ["optimade", "materials", "database"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 
 dependencies = [
@@ -81,7 +82,7 @@ include = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 ignore_missing_imports = true
 scripts_are_modules = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ docs = [
     "mkdocstrings[python-legacy]~=0.24.0",
 ]
 dev = [
+    "mongomock_motor~=0.0.25",
     "optimade-gateway[docs]",
     "pre-commit~=3.4",
     "pytest~=7.4",
@@ -90,7 +91,13 @@ allow_redefinition = true
 [tool.pytest.ini_options]
 minversion = "7.4"
 addopts = "-rs --cov=./optimade_gateway/ --cov-report=term-missing:skip-covered --no-cov-on-fail"
-filterwarnings = ["error"]
+filterwarnings = [
+    # Treat all warnings as errors
+    "error",
+
+    # mongomock uses pkg_resources
+    "ignore:.*pkg_resources is deprecated as an API.*:DeprecationWarning",
+]
 asyncio_mode = "auto"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ docs = [
     "mkdocs~=1.5",
     "mkdocs-awesome-pages-plugin~=2.9",
     "mkdocs-material~=9.4",
-    "mkdocstrings[python-legacy]~=0.23.0",
+    "mkdocstrings[python-legacy]~=0.24.0",
 ]
 dev = [
     "optimade-gateway[docs]",
@@ -49,7 +49,7 @@ dev = [
     "pytest-asyncio~=0.21.1",
     "pytest-cov~=4.1",
     "pytest-httpx~=0.22.0; python_version < '3.9'",
-    "pytest-httpx~=0.26.0; python_version >= '3.9'",
+    "pytest-httpx~=0.27.0; python_version >= '3.9'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ docs = [
     "mkdocs~=1.5",
     "mkdocs-awesome-pages-plugin~=2.9",
     "mkdocs-material~=9.4",
-    "mkdocstrings[python-legacy]~=0.24.0",
+    "mkdocstrings[python]~=0.24.0",
 ]
 dev = [
     "mongomock_motor~=0.0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ ignore = [
     "PLR",  # Design related pylint codes
     "B028",  # Bugbear: No explicit 'stacklevel' keyword argument to 'warnings.warn' call
 ]
-isort.required-imports = ["from __future__ import annotations"]
+# isort.required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-    "mike~=1.1",
+    "mike~=2.0",
     "mkdocs~=1.5",
     "mkdocs-awesome-pages-plugin~=2.9",
     "mkdocs-material~=9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,39 @@ minversion = "7.4"
 addopts = "-rs --cov=./optimade_gateway/ --cov-report=term-missing:skip-covered --no-cov-on-fail"
 filterwarnings = ["error"]
 asyncio_mode = "auto"
+
+[tool.ruff.lint]
+extend-select = [
+    "E",  # pycodestyle
+    "F",  # pyflakes
+    "B",  # flake8-bugbear
+    "I",  # isort
+    "ARG",  # flake8-unused-arguments
+    "C4",  # flake8-comprehensions
+    "ICN",  # flake8-import-conventions
+    "G",  # flake8-logging-format
+    "PGH",  # pygrep-hooks
+    "PIE",  # flake8-pie
+    "PL",  # pylint
+    "PT",  # flake8-pytest-style
+    "PTH",  # flake8-use-pathlib
+    "RET",  # flake8-return
+    "RUF",  # Ruff-specific
+    "SIM",  # flake8-simplify
+    "T20",  # flake8-print
+    "YTT",  # flake8-2020
+    "EXE",  # flake8-executable
+    "NPY",  # NumPy specific rules
+    "PYI",  # flake8-pyi
+]
+ignore = [
+    "PLR",  # Design related pylint codes
+    "B028",  # Bugbear: No explicit 'stacklevel' keyword argument to 'warnings.warn' call
+]
+isort.required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["T20"]
+"optimade_gateway/run.py" = ["T20"]
+"optimade_gateway/models/**" = ["B006"]
+"optimade_gateway/queries/params.py" = ["B006"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Intended Audience :: Developers",
@@ -24,14 +23,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 keywords = ["optimade", "materials", "database"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 dependencies = [
     "httpx>=0.24.1,<1",
     "motor~=3.3",
-    "optimade[server]~=0.24.1; python_version < '3.9'",
-    "optimade[server]~=1.0.0; python_version >= '3.9'",
+    "optimade[server]~=1.0",
 ]
 
 [project.optional-dependencies]
@@ -48,8 +46,7 @@ dev = [
     "pytest~=7.4",
     "pytest-asyncio~=0.21.1",
     "pytest-cov~=4.1",
-    "pytest-httpx~=0.22.0; python_version < '3.9'",
-    "pytest-httpx~=0.27.0; python_version >= '3.9'",
+    "pytest-httpx~=0.27.0",
 ]
 
 [project.urls]
@@ -83,7 +80,7 @@ include = [
 ]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 ignore_missing_imports = true
 scripts_are_modules = true
 warn_unused_configs = true
@@ -91,10 +88,7 @@ show_error_codes = true
 allow_redefinition = true
 
 [tool.pytest.ini_options]
-minversion = "7.0"
-required_plugins = "pytest-asyncio pytest-cov pytest-httpx"
-addopts = "-rs --cov=./optimade_gateway/ --cov-report=term --durations=10"
-filterwarnings = [
-    "ignore:.*imp module.*:DeprecationWarning"
-]
+minversion = "7.4"
+addopts = "-rs --cov=./optimade_gateway/ --cov-report=term-missing:skip-covered --no-cov-on-fail"
+filterwarnings = ["error"]
 asyncio_mode = "auto"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Awaitable, Callable
-    else:
-        from typing import Awaitable, Callable
-
+    from collections.abc import Awaitable, Callable
     from typing import Union
 
     try:

--- a/tests/queries/test_perform.py
+++ b/tests/queries/test_perform.py
@@ -1,4 +1,6 @@
 """Test queries/perform.py"""
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -8,7 +10,7 @@ if TYPE_CHECKING:
 
 
 async def test_db_get_all_resources_recursivity(
-    httpx_mock: "HTTPXMock", generic_meta: dict
+    httpx_mock: HTTPXMock, generic_meta: dict
 ) -> None:
     """Test the recursivity of db_get_all_resources()"""
     import re
@@ -73,7 +75,7 @@ async def test_db_get_all_resources_recursivity(
 
 
 async def test_db_get_all_resources_error_response(
-    httpx_mock: "HTTPXMock", caplog: pytest.LogCaptureFixture, generic_meta: dict
+    httpx_mock: HTTPXMock, caplog: pytest.LogCaptureFixture, generic_meta: dict
 ) -> None:
     """Test db_get_all_resources when an ErrorResponse is received"""
     import re

--- a/tests/routers/test_databases.py
+++ b/tests/routers/test_databases.py
@@ -1,4 +1,6 @@
 """Tests for /databases endpoints"""
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -10,8 +12,8 @@ if TYPE_CHECKING:
 
 
 async def test_get_databases(
-    client: "AsyncGatewayClient",
-    top_dir: "Path",
+    client: AsyncGatewayClient,
+    top_dir: Path,
 ) -> None:
     """Test GET /databases"""
     import json
@@ -24,16 +26,17 @@ async def test_get_databases(
     response = DatabasesResponse(**response.json())
     assert response
 
-    with open(top_dir / "tests/static/test_databases.json") as handle:
-        test_data = json.load(handle)
+    test_data = json.loads(
+        (top_dir / "tests" / "static" / "test_databases.json").read_text()
+    )
 
     assert response.meta.data_returned == len(test_data)
     assert response.meta.data_available == len(test_data)
     assert not response.meta.more_data_available
 
 
-@pytest.mark.usefixtures("reset_db_after")
-async def test_post_databases(client: "AsyncGatewayClient") -> None:
+@pytest.mark.usefixtures("_reset_db_after")
+async def test_post_databases(client: AsyncGatewayClient) -> None:
     """Test POST /databases"""
     from bson.objectid import ObjectId
     from optimade.server.routers.utils import BASE_URL_PREFIXES
@@ -83,8 +86,8 @@ async def test_post_databases(client: "AsyncGatewayClient") -> None:
 
 
 async def test_get_single_database(
-    client: "AsyncGatewayClient",
-    top_dir: "Path",
+    client: AsyncGatewayClient,
+    top_dir: Path,
 ) -> None:
     """Test GET /databases/{id}"""
     import json
@@ -109,8 +112,10 @@ async def test_get_single_database(
     datum = response.data
     assert datum, response
 
-    with open(top_dir / "tests/static/test_databases.json") as handle:
-        all_test_data = json.load(handle)
+    all_test_data = json.loads(
+        (top_dir / "tests" / "static" / "test_databases.json").read_text()
+    )
+
     for data in all_test_data:
         if data["id"] == database_id:
             test_data = data

--- a/tests/routers/test_databases.py
+++ b/tests/routers/test_databases.py
@@ -61,7 +61,7 @@ async def test_post_databases(client: AsyncGatewayClient) -> None:
 
     assert getattr(
         response.meta, f"_{CONFIG.provider.prefix}_created"
-    ), response.meta.dict()
+    ), response.meta.model_dump()
 
     datum = response.data
     assert datum, response
@@ -69,8 +69,8 @@ async def test_post_databases(client: AsyncGatewayClient) -> None:
     for field in data:
         assert (
             getattr(response.data.attributes, field) == data[field]
-        ), f"Response: {response.data.attributes.dict()!r}\n\nTest data: {data!r}"
-    assert datum.links.dict() == {
+        ), f"Response: {response.data.attributes.model_dump()!r}\n\nTest data: {data!r}"
+    assert datum.links.model_dump() == {
         "self": AnyUrl(
             url=f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}/databases/{datum.id}",
             scheme=url.scheme,
@@ -129,10 +129,11 @@ async def test_get_single_database(
         if field in ("id", "type", "links", "relationships", "meta"):
             continue
         assert (
-            await clean_python_types(response.data.attributes.dict()[field])
+            await clean_python_types(response.data.attributes.model_dump()[field])
             == data[field]
         ), (
-            f"Field: {field!r}\n\nResponse: {response.data.attributes.dict()!r}\n\n"
+            "Field: "
+            f"{field!r}\n\nResponse: {response.data.attributes.model_dump()!r}\n\n"
             f"Test data: {data!r}"
         )
     test_links = {
@@ -146,8 +147,8 @@ async def test_get_single_database(
         )
     }
     assert (
-        datum.links.dict() == test_links
-    ), f"Response: {datum.links.dict()}\n\nTest data: {test_links}"
+        datum.links.model_dump() == test_links
+    ), f"Response: {datum.links.model_dump()}\n\nTest data: {test_links}"
 
     mongo_filter = {"id": datum.id}
     assert await MONGO_DB["databases"].count_documents(mongo_filter) == 1

--- a/tests/routers/test_databases.py
+++ b/tests/routers/test_databases.py
@@ -68,13 +68,15 @@ async def test_post_databases(client: AsyncGatewayClient) -> None:
     for field in data:
         value = getattr(response.data.attributes, field)
         if isinstance(value, AnyUrl):
-            assert (
-                str(value) == data[field]
-            ), f"Response: {response.data.attributes.model_dump()!r}\n\nTest data: {data!r}"
+            assert str(value) == data[field], (
+                f"Response: {response.data.attributes.model_dump()!r}\n\n"
+                f"Test data: {data!r}"
+            )
         else:
-            assert (
-                value == data[field]
-            ), f"Response: {response.data.attributes.model_dump()!r}\n\nTest data: {data!r}"
+            assert value == data[field], (
+                f"Response: {response.data.attributes.model_dump()!r}\n\n"
+                f"Test data: {data!r}"
+            )
     assert datum.links.model_dump() == {
         "self": AnyUrl(
             f"{'/'.join(str(url).split('/')[:-1])}"

--- a/tests/routers/test_gateways.py
+++ b/tests/routers/test_gateways.py
@@ -75,7 +75,9 @@ async def test_post_gateways(client: AsyncGatewayClient) -> None:
     datum = response.data
     assert datum, response
 
-    for response_db, test_db in zip(datum.attributes.databases, data["databases"]):
+    for response_db, test_db in zip(
+        datum.attributes.databases, data["databases"], strict=True
+    ):
         assert (
             response_db.model_dump() == LinksResource(**test_db).model_dump()
         ), f"Response: {response_db!r}\n\nTest data: {LinksResource(**test_db)!r}"

--- a/tests/routers/test_gateways.py
+++ b/tests/routers/test_gateways.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 if TYPE_CHECKING:
     from pathlib import Path
 

--- a/tests/routers/test_gateways.py
+++ b/tests/routers/test_gateways.py
@@ -1,4 +1,6 @@
 """Tests for /gateways endpoints"""
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -10,8 +12,8 @@ if TYPE_CHECKING:
 
 
 async def test_get_gateways(
-    client: "AsyncGatewayClient",
-    top_dir: "Path",
+    client: AsyncGatewayClient,
+    top_dir: Path,
 ) -> None:
     """Test GET /gateways"""
     import json
@@ -24,16 +26,17 @@ async def test_get_gateways(
     response = GatewaysResponse(**response.json())
     assert response
 
-    with open(top_dir / "tests/static/test_gateways.json") as handle:
-        test_data = json.load(handle)
+    test_data = json.loads(
+        (top_dir / "tests" / "static" / "test_gateways.json").read_text()
+    )
 
     assert response.meta.data_returned == len(test_data)
     assert response.meta.data_available == len(test_data)
     assert not response.meta.more_data_available
 
 
-@pytest.mark.usefixtures("reset_db_after")
-async def test_post_gateways(client: "AsyncGatewayClient") -> None:
+@pytest.mark.usefixtures("_reset_db_after")
+async def test_post_gateways(client: AsyncGatewayClient) -> None:
     """Test POST /gateways"""
     from bson.objectid import ObjectId
     from optimade.models import LinksResource
@@ -94,8 +97,8 @@ async def test_post_gateways(client: "AsyncGatewayClient") -> None:
 
 
 async def test_path_id_raises(
-    client: "AsyncGatewayClient",
-    top_dir: "Path",
+    client: AsyncGatewayClient,
+    top_dir: Path,
 ) -> None:
     """Ensure a suggested gateway id with a forward slash gives an error"""
     import json
@@ -115,13 +118,14 @@ async def test_path_id_raises(
     mongo_filter = {"id": bad_gateway_id}
     assert await MONGO_DB["gateways"].count_documents(mongo_filter) == 0
 
-    with open(top_dir / "tests/static/test_gateways.json") as handle:
-        test_data = json.load(handle)
+    test_data = json.loads(
+        (top_dir / "tests" / "static" / "test_gateways.json").read_text()
+    )
 
     assert await MONGO_DB["gateways"].count_documents({}) == len(test_data)
 
 
-async def test_post_gateways_database_ids(client: "AsyncGatewayClient") -> None:
+async def test_post_gateways_database_ids(client: AsyncGatewayClient) -> None:
     """Test POST /gateways with `database_ids` specified"""
     from optimade.server.routers.utils import BASE_URL_PREFIXES
     from pydantic import AnyUrl
@@ -167,8 +171,8 @@ async def test_post_gateways_database_ids(client: "AsyncGatewayClient") -> None:
         assert db["id"] in data["database_ids"]
 
 
-@pytest.mark.usefixtures("reset_db_after")
-async def test_post_gateways_create_with_db_ids(client: "AsyncGatewayClient") -> None:
+@pytest.mark.usefixtures("_reset_db_after")
+async def test_post_gateways_create_with_db_ids(client: AsyncGatewayClient) -> None:
     """Test POST /gateways with `database_ids`, while creating gateway"""
     from optimade.server.routers.utils import BASE_URL_PREFIXES
     from pydantic import AnyUrl
@@ -228,9 +232,9 @@ async def test_post_gateways_create_with_db_ids(client: "AsyncGatewayClient") ->
 
 
 async def test_get_single_gateway(
-    client: "AsyncGatewayClient",
+    client: AsyncGatewayClient,
     random_gateway: str,
-    top_dir: "Path",
+    top_dir: Path,
 ) -> None:
     """Test GET /gateways/{gateway_id}"""
     import json
@@ -243,8 +247,9 @@ async def test_get_single_gateway(
     response = GatewaysResponseSingle(**response.json())
     assert response
 
-    with open(top_dir / "tests/static/test_gateways.json") as handle:
-        test_data = json.load(handle)
+    test_data = json.loads(
+        (top_dir / "tests" / "static" / "test_gateways.json").read_text()
+    )
 
     assert response.meta.data_returned == 1
     assert response.meta.data_available == len(test_data)

--- a/tests/routers/test_gateways.py
+++ b/tests/routers/test_gateways.py
@@ -35,7 +35,6 @@ async def test_get_gateways(
     assert not response.meta.more_data_available
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_post_gateways(client: AsyncGatewayClient) -> None:
     """Test POST /gateways"""
     from bson.objectid import ObjectId
@@ -56,7 +55,7 @@ async def test_post_gateways(client: AsyncGatewayClient) -> None:
                     "name": "PyTest test_post_gateways",
                     "description": "This is a valid test database",
                     "base_url": "https://example.org/test",
-                    "homepage": "https://example.org",
+                    "homepage": "https://example.org/",
                     "link_type": "child",
                 },
             }
@@ -84,9 +83,8 @@ async def test_post_gateways(client: AsyncGatewayClient) -> None:
         ), f"Response: {response_db!r}\n\nTest data: {LinksResource(**test_db)!r}"
     assert datum.links.model_dump() == {
         "self": AnyUrl(
-            url=f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}/gateways/{datum.id}",
-            scheme=url.scheme,
-            host=url.host,
+            f"{'/'.join(str(url).split('/')[:-1])}"
+            f"{BASE_URL_PREFIXES['major']}/gateways/{datum.id}"
         )
     }
 
@@ -158,9 +156,8 @@ async def test_post_gateways_database_ids(client: AsyncGatewayClient) -> None:
 
     assert datum.links.model_dump() == {
         "self": AnyUrl(
-            url=f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}/gateways/{datum.id}",
-            scheme=url.scheme,
-            host=url.host,
+            f"{'/'.join(str(url).split('/')[:-1])}"
+            f"{BASE_URL_PREFIXES['major']}/gateways/{datum.id}"
         )
     }
 
@@ -171,7 +168,6 @@ async def test_post_gateways_database_ids(client: AsyncGatewayClient) -> None:
         assert db["id"] in data["database_ids"]
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_post_gateways_create_with_db_ids(client: AsyncGatewayClient) -> None:
     """Test POST /gateways with `database_ids`, while creating gateway"""
     from optimade.server.routers.utils import BASE_URL_PREFIXES
@@ -190,7 +186,7 @@ async def test_post_gateways_create_with_db_ids(client: AsyncGatewayClient) -> N
                     "name": "PyTest test_post_gateways",
                     "description": "This is a valid test database",
                     "base_url": "https://example.org/test",
-                    "homepage": "https://example.org",
+                    "homepage": "https://example.org/",
                     "link_type": "child",
                 },
             }
@@ -218,9 +214,8 @@ async def test_post_gateways_create_with_db_ids(client: AsyncGatewayClient) -> N
 
     assert datum.links.model_dump() == {
         "self": AnyUrl(
-            url=f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}/gateways/{datum.id}",
-            scheme=url.scheme,
-            host=url.host,
+            f"{'/'.join(str(url).split('/')[:-1])}"
+            f"{BASE_URL_PREFIXES['major']}/gateways/{datum.id}",
         )
     }
 

--- a/tests/routers/test_gateways.py
+++ b/tests/routers/test_gateways.py
@@ -73,16 +73,16 @@ async def test_post_gateways(client: AsyncGatewayClient) -> None:
 
     assert getattr(
         response.meta, f"_{CONFIG.provider.prefix}_created"
-    ), response.meta.dict()
+    ), response.meta.model_dump()
 
     datum = response.data
     assert datum, response
 
     for response_db, test_db in zip(datum.attributes.databases, data["databases"]):
         assert (
-            response_db.dict() == LinksResource(**test_db).dict()
+            response_db.model_dump() == LinksResource(**test_db).model_dump()
         ), f"Response: {response_db!r}\n\nTest data: {LinksResource(**test_db)!r}"
-    assert datum.links.dict() == {
+    assert datum.links.model_dump() == {
         "self": AnyUrl(
             url=f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}/gateways/{datum.id}",
             scheme=url.scheme,
@@ -147,7 +147,7 @@ async def test_post_gateways_database_ids(client: AsyncGatewayClient) -> None:
 
     assert not getattr(
         response.meta, f"_{CONFIG.provider.prefix}_created"
-    ), response.meta.dict()
+    ), response.meta.model_dump()
 
     datum = response.data
     assert datum, response
@@ -156,7 +156,7 @@ async def test_post_gateways_database_ids(client: AsyncGatewayClient) -> None:
     for database in datum.attributes.databases:
         assert database.id in data["database_ids"]
 
-    assert datum.links.dict() == {
+    assert datum.links.model_dump() == {
         "self": AnyUrl(
             url=f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}/gateways/{datum.id}",
             scheme=url.scheme,
@@ -208,7 +208,7 @@ async def test_post_gateways_create_with_db_ids(client: AsyncGatewayClient) -> N
 
     assert getattr(
         response.meta, f"_{CONFIG.provider.prefix}_created"
-    ), response.meta.dict()
+    ), response.meta.model_dump()
 
     datum = response.data
     assert datum, response
@@ -216,7 +216,7 @@ async def test_post_gateways_create_with_db_ids(client: AsyncGatewayClient) -> N
     for database in datum.attributes.databases:
         assert database.id in [data["databases"][0]["id"], data["database_ids"][0]]
 
-    assert datum.links.dict() == {
+    assert datum.links.model_dump() == {
         "self": AnyUrl(
             url=f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}/gateways/{datum.id}",
             scheme=url.scheme,

--- a/tests/routers/test_info.py
+++ b/tests/routers/test_info.py
@@ -1,12 +1,13 @@
 """Tests for /info endpoint"""
-from typing import TYPE_CHECKING
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..conftest import AsyncGatewayClient
 
 
-async def test_get_info(client: "AsyncGatewayClient") -> None:
+async def test_get_info(client: AsyncGatewayClient) -> None:
     """Test GET /info"""
     from optimade.models import InfoResponse
 
@@ -42,7 +43,7 @@ async def test_get_info(client: "AsyncGatewayClient") -> None:
     )
 
 
-async def test_get_info_entry(client: "AsyncGatewayClient") -> None:
+async def test_get_info_entry(client: AsyncGatewayClient) -> None:
     """Test GET /info/{entry}"""
     from optimade.models import EntryInfoResponse
 

--- a/tests/routers/test_links.py
+++ b/tests/routers/test_links.py
@@ -1,12 +1,13 @@
 """Tests for /links endpoint"""
-from typing import TYPE_CHECKING
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..conftest import AsyncGatewayClient
 
 
-async def test_get_links(client: "AsyncGatewayClient") -> None:
+async def test_get_links(client: AsyncGatewayClient) -> None:
     """Test GET /links"""
     from optimade.models import LinksResponse
 

--- a/tests/routers/test_queries.py
+++ b/tests/routers/test_queries.py
@@ -1,4 +1,6 @@
 """Tests for /queries endpoints"""
+from __future__ import annotations
+
 import json
 from typing import TYPE_CHECKING
 
@@ -12,8 +14,8 @@ if TYPE_CHECKING:
 
 
 async def test_get_queries(
-    client: "AsyncGatewayClient",
-    top_dir: "Path",
+    client: AsyncGatewayClient,
+    top_dir: Path,
 ) -> None:
     """Test GET /queries"""
     from optimade_gateway.models.responses import QueriesResponse
@@ -33,11 +35,11 @@ async def test_get_queries(
     assert not response.meta.more_data_available
 
 
-@pytest.mark.usefixtures("reset_db_after")
+@pytest.mark.usefixtures("_reset_db_after")
 async def test_post_queries(
-    client: "AsyncGatewayClient",
-    mock_gateway_responses: "Callable[[dict], None]",
-    get_gateway: "Callable[[str], Awaitable[dict]]",
+    client: AsyncGatewayClient,
+    mock_gateway_responses: Callable[[dict], None],
+    get_gateway: Callable[[str], Awaitable[dict]],
 ) -> None:
     """Test POST /queries"""
     import asyncio
@@ -103,8 +105,8 @@ async def test_post_queries(
     await asyncio.sleep(1)  # Ensure mock URL is queried
 
 
-@pytest.mark.usefixtures("reset_db_after")
-async def test_post_queries_bad_data(client: "AsyncGatewayClient") -> None:
+@pytest.mark.usefixtures("_reset_db_after")
+async def test_post_queries_bad_data(client: AsyncGatewayClient) -> None:
     """Test POST /queries with bad data"""
     from optimade.models import ErrorResponse, OptimadeError
 
@@ -139,11 +141,11 @@ async def test_post_queries_bad_data(client: "AsyncGatewayClient") -> None:
     )
 
 
-@pytest.mark.usefixtures("reset_db_after")
+@pytest.mark.usefixtures("_reset_db_after")
 async def test_query_results(
-    client: "AsyncGatewayClient",
-    mock_gateway_responses: "Callable[[dict], None]",
-    get_gateway: "Callable[[str], Awaitable[dict]]",
+    client: AsyncGatewayClient,
+    mock_gateway_responses: Callable[[dict], None],
+    get_gateway: Callable[[str], Awaitable[dict]],
 ) -> None:
     """Test POST /queries and GET /queries/{id}"""
     import asyncio
@@ -186,11 +188,11 @@ async def test_query_results(
     assert response.data.attributes.state == QueryState.FINISHED
 
 
-@pytest.mark.usefixtures("reset_db_after")
+@pytest.mark.usefixtures("_reset_db_after")
 async def test_errored_query_results(
-    client: "AsyncGatewayClient",
-    mock_gateway_responses: "Callable[[dict], None]",
-    get_gateway: "Callable[[str], Awaitable[dict]]",
+    client: AsyncGatewayClient,
+    mock_gateway_responses: Callable[[dict], None],
+    get_gateway: Callable[[str], Awaitable[dict]],
 ) -> None:
     """Test POST /queries and GET /queries/{id} with an erroneous response"""
     import asyncio
@@ -222,11 +224,11 @@ async def test_errored_query_results(
     assert response.data.attributes.response.errors
 
 
-@pytest.mark.usefixtures("reset_db_after")
+@pytest.mark.usefixtures("_reset_db_after")
 async def test_sort_no_effect(
-    client: "AsyncGatewayClient",
-    get_gateway: "Callable[[str], Awaitable[dict]]",
-    mock_gateway_responses: "Callable[[dict], None]",
+    client: AsyncGatewayClient,
+    get_gateway: Callable[[str], Awaitable[dict]],
+    mock_gateway_responses: Callable[[dict], None],
 ) -> None:
     """Test POST /queries with the `sort` query parameter
 

--- a/tests/routers/test_queries.py
+++ b/tests/routers/test_queries.py
@@ -5,13 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Awaitable, Callable
-    else:
-        from typing import Awaitable, Callable
-
+    from collections.abc import Awaitable, Callable
     from pathlib import Path
 
     from ..conftest import AsyncGatewayClient

--- a/tests/routers/test_queries.py
+++ b/tests/routers/test_queries.py
@@ -34,7 +34,6 @@ async def test_get_queries(
     assert not response.meta.more_data_available
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_post_queries(
     client: AsyncGatewayClient,
     mock_gateway_responses: MockGatewayResponses,
@@ -84,12 +83,8 @@ async def test_post_queries(
 
     assert datum.links.model_dump() == {
         "self": AnyUrl(
-            url=(
-                f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}"
-                f"/queries/{datum.id}"
-            ),
-            scheme=url.scheme,
-            host=url.host,
+            f"{'/'.join(str(url).split('/')[:-1])}{BASE_URL_PREFIXES['major']}"
+            f"/queries/{datum.id}"
         )
     }
     assert datum.attributes.state == QueryState.CREATED
@@ -104,7 +99,6 @@ async def test_post_queries(
     await asyncio.sleep(1)  # Ensure mock URL is queried
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_post_queries_bad_data(client: AsyncGatewayClient) -> None:
     """Test POST /queries with bad data"""
     from optimade.models import ErrorResponse, OptimadeError
@@ -140,7 +134,6 @@ async def test_post_queries_bad_data(client: AsyncGatewayClient) -> None:
     )
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_query_results(
     client: AsyncGatewayClient,
     mock_gateway_responses: MockGatewayResponses,
@@ -187,7 +180,6 @@ async def test_query_results(
     assert response.data.attributes.state == QueryState.FINISHED
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_errored_query_results(
     client: AsyncGatewayClient,
     mock_gateway_responses: MockGatewayResponses,
@@ -223,7 +215,6 @@ async def test_errored_query_results(
     assert response.data.attributes.response.errors
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_sort_no_effect(
     client: AsyncGatewayClient,
     get_gateway: GetGateway,

--- a/tests/routers/test_search.py
+++ b/tests/routers/test_search.py
@@ -4,13 +4,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Awaitable, Callable
-    else:
-        from typing import Awaitable, Callable
-
+    from collections.abc import Awaitable, Callable
     from pathlib import Path
 
     from ..conftest import AsyncGatewayClient

--- a/tests/routers/test_search.py
+++ b/tests/routers/test_search.py
@@ -118,7 +118,7 @@ async def test_get_as_optimade(
 ) -> None:
     """Test GET /search with `as_optimade=True`
 
-    This should be equivalent of `GET /gateways/{gateway_id}/structures`.
+    This should be equivalent to `GET /gateways/{gateway_id}/structures`.
     """
     import json
 
@@ -182,6 +182,8 @@ async def test_get_as_optimade(
     assert data_returned == response.meta.data_returned
     assert data_available == response.meta.data_available
     assert more_data_available == response.meta.more_data_available
+
+    print(response.data[0])
 
     assert data == response.model_dump(exclude_unset=True, exclude_none=True)["data"], (
         "IDs in test not in response: "

--- a/tests/routers/test_search.py
+++ b/tests/routers/test_search.py
@@ -141,7 +141,9 @@ async def test_get_as_optimade(
 
     response = await client("/search", params=query_params)
 
-    assert response.status_code == 200, f"Request failed:\n{json.dumps(response.json(), indent=2)}"
+    assert (
+        response.status_code == 200
+    ), f"Request failed:\n{json.dumps(response.json(), indent=2)}"
 
     response = StructureResponseMany(**response.json())
     assert response

--- a/tests/static/test_config.json
+++ b/tests/static/test_config.json
@@ -1,8 +1,8 @@
 {
     "debug": false,
-    "mongo_uri": "mongodb://{host_ip}:27017",
+    "mongo_uri": "mongodb://localhost:27017",
     "mongo_database": "test_optimade_gateway",
-    "database_backend": "mongodb",
+    "database_backend": "mongomock",
     "page_limit": 15,
     "page_limit_max": 500,
     "base_url": "http://example.org",
@@ -10,7 +10,7 @@
         "name": "OPTIMADE Gateway",
         "version": "0.4.0",
         "source_url": "https://github.com/Materials-Consortia/optimade-gateway",
-        "maintainer": {"email": "casper.andersen@epfl.ch"}
+        "maintainer": {"email": "casper+github@welzel.nu"}
     },
     "index_base_url": null,
     "provider": {

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
     from pathlib import Path
     from typing import Any
 
     from pytest_httpx import HTTPXMock
+
+    from .conftest import GetGateway, MockGatewayResponses
 
 
 @pytest.mark.usefixtures("_reset_db_after")
@@ -384,8 +385,8 @@ async def test_load_databases_valid_databases(
     httpx_mock: HTTPXMock,
     caplog: pytest.LogCaptureFixture,
     top_dir: Path,
-    get_gateway: Callable[[str], Awaitable[dict]],
-    mock_gateway_responses: Callable[[dict], None],
+    get_gateway: GetGateway,
+    mock_gateway_responses: MockGatewayResponses,
 ) -> None:
     """Test load_optimade_providers_databases() when valid CHILD dbs are found and
     added"""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,13 +4,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    import platform
-
-    if platform.python_version() >= "3.9.0":
-        from collections.abc import Awaitable, Callable
-    else:
-        from typing import Awaitable, Callable
-
+    from collections.abc import Awaitable, Callable
     from pathlib import Path
 
     from pytest_httpx import HTTPXMock

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from .conftest import GetGateway, MockGatewayResponses
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_ci_dev_startup_ci(
     caplog: pytest.LogCaptureFixture, top_dir: Path
 ) -> None:
@@ -67,7 +66,6 @@ async def test_ci_dev_startup_ci(
             del os.environ["CI"]
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_ci_dev_startup_dev(
     caplog: pytest.LogCaptureFixture, top_dir: Path
 ) -> None:
@@ -125,7 +123,6 @@ async def test_ci_dev_startup_dev(
             del os.environ["OPTIMADE_MONGO_DATABASE"]
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_ci_dev_startup_nothing(caplog: pytest.LogCaptureFixture) -> None:
     """Test ci_dev_startup() if not in CI or development mode"""
     import os
@@ -380,7 +377,6 @@ async def test_load_databases_no_databases(
         CONFIG.load_optimade_providers_databases = org_val
 
 
-@pytest.mark.usefixtures("_reset_db_after")
 async def test_load_databases_valid_databases(
     httpx_mock: HTTPXMock,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
Closes #433 

Also improves the code base in general:
- Drop Python 3.9 support, but add Python 3.11 and Python 3.12 support.
- Use Python 3.10 throughout as the default Python version.
- Use most Python parser for `mkdocstrings`.
- Add `pyupgrade` as a pre-commit hook.
- Update `ruff` rules.
- Change the testing backend to be a mock backend. Use `mongomock_motor` for this to work.