### PR TITLE
Update to pytest-asyncio v0.23

### DIFF
--- a/optimade_gateway/mongo/database.py
+++ b/optimade_gateway/mongo/database.py
@@ -2,20 +2,12 @@
 
 from __future__ import annotations
 
-from os import getenv
-from typing import TYPE_CHECKING
-
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from optimade_gateway.common.config import CONFIG
 from optimade_gateway.common.logger import LOGGER
 
-if TYPE_CHECKING or bool(getenv("MKDOCS_BUILD", "")):  # pragma: no cover
-    from pymongo.database import Database
-    from pymongo.mongo_client import MongoClient
-
-
-MONGO_CLIENT: MongoClient = AsyncIOMotorClient(
+MONGO_CLIENT = AsyncIOMotorClient(
     CONFIG.mongo_uri,
     appname="optimade-gateway",
     readConcernLevel="majority",
@@ -24,7 +16,7 @@ MONGO_CLIENT: MongoClient = AsyncIOMotorClient(
 )
 """The MongoDB motor client."""
 
-MONGO_DB: Database = MONGO_CLIENT[CONFIG.mongo_database]
+MONGO_DB = MONGO_CLIENT[CONFIG.mongo_database]
 """The MongoDB motor database.
 This is a representation of the database used for the gateway service."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ dev = [
     "mongomock_motor~=0.0.29",
     "optimade-gateway[docs]",
     "pre-commit~=3.7",
-    "pytest>=7.4.0,<9",
-    "pytest-asyncio>=0.21.1,<0.23",
+    "pytest~=8.2",
+    "pytest-asyncio~=0.23.6",
     "pytest-cov~=5.0",
     "pytest-httpx~=0.30.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,25 +183,6 @@ def pytest_configure(config: pytest.Config):  # noqa: ARG001
     os.environ["OPTIMADE_CONFIG_FILE"] = str(cwd / "static/test_config.json")
 
 
-def pytest_collection_modifyitems(
-    session: pytest.Session,  # noqa: ARG001
-    config: pytest.Config,  # noqa: ARG001
-    items: list[pytest.Item],
-):
-    """Called after collection has been performed. May filter or re-order the items
-    in-place.
-
-    ---
-
-    Here, we mark all async tests with the `session` scope, so that they are run in a
-    single event loop.
-    """
-    from pytest_asyncio import is_async_test
-
-    for async_test in (item for item in items if is_async_test(item)):
-        async_test.add_marker(pytest.mark.asyncio(scope="session"), append=False)
-
-
 # PYTEST FIXTURES
 
 
@@ -291,7 +272,7 @@ async def random_gateway() -> dict:
 
 @pytest.fixture(autouse=True)
 async def _reset_db_after(top_dir: Path) -> None:
-    """Reset MongoDB with original test data after the test has run"""
+    """Reset MongoDB with original test data before the test has run"""
     try:
         yield
     finally:


### PR DESCRIPTION
Fixes #447 

This will implement a pytest session-scoped asyncio-loop using the [`pytest_configuration_modifyitems()`](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_collection_modifyitems) function as described in the [pytest-asyncio documentation](https://pytest-asyncio.readthedocs.io/en/latest/how-to-guides/run_session_tests_in_same_loop.html) to ensure we have a session-scoped event loop.

The behavior of overwriting the `event_loop` fixture is deprecated in pytest-asyncio from v0.23.